### PR TITLE
feat: add support for ensemble model statistics

### DIFF
--- a/src/jua/weather/__init__.py
+++ b/src/jua/weather/__init__.py
@@ -2,6 +2,7 @@ from jua.weather._jua_dataset import JuaDataset
 from jua.weather._model import Model
 from jua.weather._weather import Weather
 from jua.weather.models import Models
+from jua.weather.statistics import Statistics
 from jua.weather.variables import Variables
 
-__all__ = ["Model", "Models", "Variables", "JuaDataset", "Weather"]
+__all__ = ["JuaDataset", "Model", "Models", "Statistics", "Variables", "Weather"]

--- a/src/jua/weather/_model_meta.py
+++ b/src/jua/weather/_model_meta.py
@@ -11,6 +11,7 @@ class ModelMetaInfo:
     forecast_name_mapping: str | None = None
     full_forecasted_hours: int | None = None
     has_forecast_file_access: bool = False
+    has_statistics: bool = False
 
 
 _MODEL_META_INFO = defaultdict(ModelMetaInfo)
@@ -48,6 +49,7 @@ _MODEL_META_INFO[Models.EPT2_E] = ModelMetaInfo(
     forecast_name_mapping="ept2-e",
     full_forecasted_hours=480,
     has_forecast_file_access=True,
+    has_statistics=True,
 )
 _MODEL_META_INFO[Models.ECMWF_IFS_SINGLE] = ModelMetaInfo(
     has_forecast_file_access=False,

--- a/src/jua/weather/_types/api_payload_types.py
+++ b/src/jua/weather/_types/api_payload_types.py
@@ -9,3 +9,4 @@ class ForecastRequestPayload(BaseModel):
     max_lead_time: int = 0
     variables: list[str] | None = None
     full: bool = False
+    ensemble_stats: list[str] | None = None

--- a/src/jua/weather/_types/api_response_types.py
+++ b/src/jua/weather/_types/api_response_types.py
@@ -21,6 +21,7 @@ class ForecastMetadataResponse(BaseModel):
     init_time: datetime
     available_forecasted_hours: int
     available_variables: list[str]
+    available_ensemble_stats: list[str]
 
 
 class ForecastResponse(BaseModel):

--- a/src/jua/weather/_types/forecast.py
+++ b/src/jua/weather/_types/forecast.py
@@ -21,18 +21,51 @@ class PointResponse(BaseModel, extra="allow"):
     requested_latlon: Point
     returned_latlon: Point
     _variables: Dict[str, List[float]]  # Added type hint and initialization
+    _statistics: (
+        Dict[str, Dict[str, List[float]]] | None
+    )  # Added type hint and initialization
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._variables = {
             rename_variable(k): v
             for k, v in kwargs.items()
-            if k not in {"requested_latlon", "returned_latlon"}
+            if k not in {"requested_latlon", "returned_latlon", "stats"}
         }
+        self._statistics = None
+        if "stats" in kwargs:
+            self._statistics = {
+                rename_variable(k): v for k, v in kwargs["stats"].items()
+            }
+
+        var_names = {k for k in self._variables.keys()}
+        if self._statistics is not None:
+            var_names.update({k for k in self._statistics.keys()})
+        self._variable_names = list(sorted(var_names))
+
+        self._statistic_names = []
+        if self._statistics is not None:
+            self._statistic_names = list(
+                self._statistics[self._variable_names[0]].keys()
+            )
+            if len(self._variables) > 0:  # mean available
+                self._statistic_names = ["mean"] + self._statistic_names
 
     @property
     def variables(self) -> Dict[str, List[float]]:
         return self._variables
+
+    @property
+    def statistics(self) -> Dict[str, Dict[str, List[float]]] | None:
+        return self._statistics
+
+    @property
+    def variable_names(self) -> List[str]:
+        return self._variable_names
+
+    @property
+    def statistic_names(self) -> List[str]:
+        return self._statistic_names
 
     def __getitem__(self, key: str) -> List[float] | None:  # Added None to return type
         if not isinstance(key, str):
@@ -40,6 +73,31 @@ class PointResponse(BaseModel, extra="allow"):
         if key not in self.variables:
             return None
         return self.variables[key]
+
+    def get_statistics(self, key: str) -> List[List[float]] | None:
+        """
+        Returns:
+            List[List[float]] | None: A list of lists of statistics.
+                If no statistics are available, returns None.
+                If the statistics are available, returns the statistics for the given
+                key in the order of statistic_names.
+        """
+        if not isinstance(key, str):
+            raise TypeError("Key must be a string")
+
+        if self.statistics is None:
+            return None
+
+        stats = []
+        stat_names = self._statistic_names
+        if self._statistic_names[0] == "mean":
+            stat_names = stat_names[1:]
+            stats.append(self.variables[key])
+
+        for stat in stat_names:
+            stats.append(self.statistics[key][stat])
+
+        return stats
 
     def __repr__(self):
         variables = "\n".join([f"{k}: {v}" for k, v in self.variables.items()])
@@ -64,7 +122,7 @@ class ForecastData:
         if len(self.points) == 0:
             return None
 
-        variable_keys = list(self.points[0].variables.keys())
+        variable_names = self.points[0].variable_names
 
         # Extract coordinate information
         returned_lats = [p.returned_latlon.lat for p in self.points]
@@ -74,15 +132,23 @@ class ForecastData:
         lons = np.unique(returned_lons)
 
         prediction_timedeltas = [t - self.init_time for t in self.times]
-
-        ds = xr.Dataset(
-            coords={
-                "time": [self.init_time],
-                "prediction_timedelta": prediction_timedeltas,
-                "latitude": lats,
-                "longitude": lons,
-            },
+        coords = {
+            "time": [self.init_time],
+            "prediction_timedelta": prediction_timedeltas,
+            "latitude": lats,
+            "longitude": lons,
+        }
+        dims: tuple[str, ...] = (
+            "time",
+            "prediction_timedelta",
+            "latitude",
+            "longitude",
         )
+        if self.points[0].statistics is not None:
+            dims = ("time", "stat", "prediction_timedelta", "latitude", "longitude")
+            coords["stat"] = self.points[0].statistic_names
+
+        ds = xr.Dataset(coords=coords)
 
         point_mapping: dict[tuple[float, float], PointResponse] = {}
         for points in self.points:
@@ -91,9 +157,23 @@ class ForecastData:
             )
 
         # Create data variables for the dataset
-        for var_key in variable_keys:
+        for var_key in variable_names:
             # Initialize array with explicit missing values (using numpy.nan)
-            data_shape = (1, len(prediction_timedeltas), len(lats), len(lons))
+            data_shape: tuple[int, ...] = (
+                1,
+                len(prediction_timedeltas),
+                len(lats),
+                len(lons),
+            )
+            if self.points[0].statistics is not None:
+                num_stats = len(coords["stat"])
+                data_shape = (
+                    1,
+                    num_stats,
+                    len(prediction_timedeltas),
+                    len(lats),
+                    len(lons),
+                )
             data_array = np.full(data_shape, np.nan)
 
             # Fill only the coordinates where we actually have data
@@ -101,15 +181,18 @@ class ForecastData:
                 for lon_idx, lon in enumerate(lons):
                     if (lat, lon) not in point_mapping:
                         continue
-                    points = point_mapping[(lat, lon)]
-                    var_values = points[var_key]
-                    data_array[0, :, lat_idx, lon_idx] = var_values
+
+                    point = point_mapping[(lat, lon)]
+                    if point.statistics is not None:
+                        data_array[0, :, :, lat_idx, lon_idx] = point.get_statistics(
+                            var_key
+                        )
+                    else:
+                        data_array[0, :, lat_idx, lon_idx] = point[var_key]
 
             # Add the variable to the dataset
-            ds[var_key] = (
-                ("time", "prediction_timedelta", "latitude", "longitude"),
-                data_array,
-            )
+            ds[var_key] = (dims, data_array)
+
         ds.attrs["model"] = self.model
         ds.attrs["id"] = self.id
         ds.attrs["name"] = self.name

--- a/src/jua/weather/_xarray_patches.py
+++ b/src/jua/weather/_xarray_patches.py
@@ -6,6 +6,7 @@ from pydantic import validate_call
 
 from jua.types.geo import LatLon, PredictionTimeDelta
 from jua.weather.conversions import to_timedelta
+from jua.weather.statistics import Statistics
 from jua.weather.variables import Variables
 
 """
@@ -130,6 +131,7 @@ def _patch_args(
     time: np.datetime64 | slice | None,
     latitude: float | slice | None,
     longitude: float | slice | None,
+    stat: str | Statistics | None = None,
     **kwargs,
 ):
     """Process and normalize arguments for patched xarray selection methods.
@@ -144,6 +146,7 @@ def _patch_args(
         time: Time selection parameter
         latitude: Latitude selection parameter
         longitude: Longitude selection parameter
+        stat: Statistic selection parameter
         **kwargs: Additional xarray selection parameters
 
     Returns:
@@ -167,6 +170,11 @@ def _patch_args(
         jua_args["latitude"] = latitude
     if longitude is not None:
         jua_args["longitude"] = longitude
+    if stat is not None:
+        if isinstance(stat, Statistics):
+            jua_args["stat"] = stat.key
+        else:
+            jua_args["stat"] = stat
 
     return {**jua_args, **kwargs}
 
@@ -199,6 +207,7 @@ def _patched_sel(
     latitude: float | slice | None = None,
     longitude: float | slice | None = None,
     points: LatLon | list[LatLon] | None = None,
+    stat: str | Statistics | None = None,
     **kwargs,
 ):
     """Core implementation of the patched selection method.
@@ -229,6 +238,7 @@ def _patched_sel(
         prediction_timedelta=prediction_timedelta,
         latitude=latitude,
         longitude=longitude,
+        stat=stat,
         **kwargs,
     )
 
@@ -483,10 +493,19 @@ class ToCelciusAccessor:
         """Convert temperature from Kelvin to Celsius.
 
         This method applies the K→°C conversion: T(°C) = T(K) - 273.15
+        If there's a stat dimension, standard deviation values are not converted
+        since they represent temperature differences, not absolute temperatures.
 
         Returns:
             Temperature data in Celsius
         """
+        # Check if there's a stat dimension
+        if "stat" in self._xarray_obj.dims:
+            is_not_std = self._xarray_obj.stat != "std"
+            result = self._xarray_obj.copy()
+            result = result.where(~is_not_std, self._xarray_obj - 273.15)
+            return result
+
         return self._xarray_obj - 273.15
 
 
@@ -656,6 +675,7 @@ if TYPE_CHECKING:
             latitude: float | slice | None = None,
             longitude: float | slice | None = None,
             points: LatLon | list[LatLon] | None = None,
+            stat: Statistics | None = None,
             **kwargs,
         ) -> "TypedDataArray": ...
 

--- a/src/jua/weather/statistics.py
+++ b/src/jua/weather/statistics.py
@@ -1,0 +1,97 @@
+# statistics.py
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+@dataclass(frozen=True)
+class Statistic:
+    """Internal representation of a statistic with associated metadata.
+
+    This class represents a statistic with standardized naming and metadata.
+
+    Attributes:
+        key: The key for the statistic in the data returned by the Jua API.
+        name: The standardized name of the statistic.
+    """
+
+    key: str
+    name: str
+
+    @property
+    def display_name(self) -> str:
+        """Return the display name of the statistic.
+
+        Returns:
+            The display name of the statistic.
+        """
+        return " ".join(word.capitalize() for word in self.name.split("_"))
+
+    def __eq__(self, other):
+        """Check if two Statistic objects are equal.
+
+        Statistics are considered equal if all their attributes match.
+
+        Args:
+            other: Another object to compare with.
+
+        Returns:
+            True if equal, False otherwise.
+        """
+        if not isinstance(other, Statistic):
+            return NotImplemented
+        return self.name == other.name
+
+    def __str__(self):
+        """Return the standardized name of the statistic.
+
+        Returns:
+            The name attribute as a string.
+        """
+        return self.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+
+class Statistics(Enum):
+    """Statistics available through the Jua API.
+
+    This enum defines the set of statistics that can be requested
+    when fetching forecasts or hindcasts. Use these constants when
+    specifying which statistic to use with weather data functions.
+    """
+
+    MEAN = Statistic(key="mean", name="mean")
+    STD = Statistic(key="std", name="standard deviation")
+    QUANTILE_5 = Statistic(key="q5", name="5th_quantile")
+    QUANTILE_25 = Statistic(key="q25", name="25th_quantile")
+    QUANTILE_75 = Statistic(key="q75", name="75th_quantile")
+    QUANTILE_95 = Statistic(key="q95", name="95th_quantile")
+
+    @property
+    def display_name(self) -> str:
+        """Return the display name of the statistic.
+
+        Returns:
+            The display name of the statistic.
+        """
+        return self.value.display_name
+
+    @property
+    def key(self) -> str:
+        """Return the key of the statistic.
+
+        Returns:
+            The key of the statistic.
+        """
+        return self.value.key
+
+    @property
+    def name(self) -> str:
+        """Return the name of the statistic.
+
+        Returns:
+            The name of the statistic.
+        """
+        return self.value.name


### PR DESCRIPTION
Adds support for ensemble member statistics in the Jua SDK.

Example usage:

```python
import matplotlib.pyplot as plt

from jua import JuaClient
from jua.settings.jua_settings import JuaSettings
from jua.weather import Statistics, Variables
from jua.weather.models import Models

settings = JuaSettings()
client = JuaClient(settings=settings)
model = client.weather.get_model(Models.EPT2_E)

# Using the Statistics enum (recommended for type safety)
forecast_data = model.forecast.get_forecast(
    latitude=51.5,
    longitude=-0.12,
    statistics=[
        Statistics.MEAN,
        Statistics.STD,
        Statistics.QUANTILE_5,
        Statistics.QUANTILE_95,
    ],
)

# Extracting the wind speed
ds_forecast = forecast_data.to_xarray()
ds_forecast = ds_forecast.isel(points=0, time=0)
wind_speed = ds_forecast[Variables.WIND_SPEED_AT_HEIGHT_LEVEL_10M]
wind_speed = wind_speed.to_absolute_time()

# Create visualizations
wind_speed.sel(stat=Statistics.MEAN).plot(label=Statistics.MEAN.display_name)
wind_speed.sel(stat=Statistics.QUANTILE_5).plot(
    label=Statistics.QUANTILE_5.display_name
)
wind_speed.sel(stat=Statistics.QUANTILE_95).plot(
    label=Statistics.QUANTILE_95.display_name
)
plt.legend()
plt.show()
```
