### PR TITLE
refactor: use the jua production domain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ uv init && uv add jua
 
 ### Authentication
 
-Generate an API key from the [Jua dashboard](https://app.jua.sh/api-keys) and save it to `~/.jua/default/api-key.json`.
+Generate an API key from the [Jua dashboard](https://app.jua.ai/api-keys) and save it to `~/.jua/default/api-key.json`.
 
 _Coming soon: Simply run `jua auth` to authenticate via your web browser._
 

--- a/src/jua/settings/jua_settings.py
+++ b/src/jua/settings/jua_settings.py
@@ -34,7 +34,7 @@ class JuaSettings(BaseSettings):
     """
 
     api_url: str = Field(
-        default="https://api.jua.sh", description="Base URL for the JUA API"
+        default="https://api.jua.ai", description="Base URL for the JUA API"
     )
 
     api_version: str = Field(
@@ -42,7 +42,7 @@ class JuaSettings(BaseSettings):
     )
 
     data_base_url: str = Field(
-        default="https://data.jua.sh", description="Base URL for JUA data services"
+        default="https://data.jua.ai", description="Base URL for JUA data services"
     )
 
     auth: AuthenticationSettings = Field(

--- a/tests/settings/test_jua_settings.py
+++ b/tests/settings/test_jua_settings.py
@@ -9,9 +9,9 @@ class TestJuaSettings:
         """Test initialization with default values."""
         settings = JuaSettings()
 
-        assert settings.api_url == "https://api.jua.sh"
+        assert settings.api_url == "https://api.jua.ai"
         assert settings.api_version == "v1"
-        assert settings.data_base_url == "https://data.jua.sh"
+        assert settings.data_base_url == "https://data.jua.ai"
         assert settings.print_progress is True
         assert isinstance(settings.auth, AuthenticationSettings)
 


### PR DESCRIPTION
We're switching from *.jua.sh to *.jua.ai. There should be no change in functionality.