### PR TITLE
fix: return a more verbose error when data is missing

### DIFF
--- a/src/jua/weather/_types/api_response_types.py
+++ b/src/jua/weather/_types/api_response_types.py
@@ -21,7 +21,7 @@ class ForecastMetadataResponse(BaseModel):
     init_time: datetime
     available_forecasted_hours: int
     available_variables: list[str]
-    available_ensemble_stats: list[str]
+    available_ensemble_stats: list[str] | None = None
 
 
 class ForecastResponse(BaseModel):

--- a/src/jua/weather/_types/forecast.py
+++ b/src/jua/weather/_types/forecast.py
@@ -188,7 +188,18 @@ class ForecastData:
                             var_key
                         )
                     else:
-                        data_array[0, :, lat_idx, lon_idx] = point[var_key]
+                        point_data = point[var_key]
+                        if point_data is None or len(point_data) != len(
+                            prediction_timedeltas
+                        ):
+                            num_values = None if point_data is None else len(point_data)
+                            raise ValueError(
+                                f"Forecast data for variable {var_key} at ({lat}, "
+                                f"{lon}) has {num_values} values, but "
+                                f"{len(prediction_timedeltas)} are expected."
+                            )
+
+                        data_array[0, :, lat_idx, lon_idx] = point_data
 
             # Add the variable to the dataset
             ds[var_key] = (dims, data_array)


### PR DESCRIPTION
- fixes the type annotation for `ForecastMetadataResponse.available_ensemble_stats`
- returns a more verbose error when incomplete data is returned by the API
