### PR TITLE
fixes access to surface_direct_downwelling and dew_point variables

### DIFF
--- a/src/jua/weather/forecast.py
+++ b/src/jua/weather/forecast.py
@@ -17,7 +17,7 @@ from jua.weather._types.forecast import ForecastData
 from jua.weather.conversions import timedelta_to_hours, to_datetime
 from jua.weather.models import Models
 from jua.weather.statistics import Statistics
-from jua.weather.variables import Variables, rename_to_ept2
+from jua.weather.variables import Variables, rename_variable
 
 logger = get_logger(__name__)
 
@@ -374,7 +374,10 @@ class Forecast:
         Returns:
             List of variable names formatted for API requests
         """
-        return [rename_to_ept2(v) for v in variables]
+        return [
+            rename_variable(v.name) if isinstance(v, Variables) else rename_variable(v)
+            for v in variables
+        ]
 
     def _dispatch_to_api(
         self,

--- a/src/jua/weather/variables.py
+++ b/src/jua/weather/variables.py
@@ -283,19 +283,6 @@ _RENAMING_DICT = {
     },
 }
 
-_RENAME_TO_EPT2_DICT = {
-    **{
-        v.value.emcwf_code: v.value.name_ept2
-        for v in Variables
-        if v.value.emcwf_code is not None
-    },
-    **{
-        v.value.name: v.value.name_ept2
-        for v in Variables
-        if v.value.name_ept2 is not None
-    },
-}
-
 
 def rename_variable(variable: str) -> str:
     """Convert variable names from model-specific formats to standardized names.
@@ -307,18 +294,6 @@ def rename_variable(variable: str) -> str:
         The standardized variable name if recognized, otherwise the original name.
     """
     return _RENAMING_DICT.get(variable, variable)
-
-
-def rename_to_ept2(variable: str | Variables) -> str:
-    """Convert variable names from model-specific formats to EPT2 names.
-
-    Args:
-        variable: The source variable name to convert.
-
-    Returns:
-        The EPT2 variable name if recognized, otherwise the original name.
-    """
-    return _RENAME_TO_EPT2_DICT.get(str(variable), str(variable))  # type: ignore
 
 
 def rename_variables(ds: xr.Dataset) -> xr.Dataset:


### PR DESCRIPTION
Fixes the variable naming in the SDK so that `surface_direct_downwelling_shortwave_flux_sum_1h` and `dew_point_temperature_at_height_level_2m` are available for different models.