### PR TITLE
feat: add temporal aggregation for market aggregates (daily, weekly)

### DIFF
--- a/src/jua/market_aggregates/__init__.py
+++ b/src/jua/market_aggregates/__init__.py
@@ -1,12 +1,21 @@
 from jua.market_aggregates.energy_market import EnergyMarket
 from jua.market_aggregates.market_aggregates import MarketAggregates
 from jua.market_aggregates.model_run import ModelRuns
-from jua.market_aggregates.variables import AggregateVariables, MWWeighting
+from jua.market_aggregates.variables import (
+    AggregateVariables,
+    AggregationFrequency,
+    AggregationMethod,
+    MWWeighting,
+    TemporalAggregation,
+)
 
 __all__ = [
     "MarketAggregates",
     "EnergyMarket",
     "AggregateVariables",
+    "AggregationFrequency",
+    "AggregationMethod",
     "MWWeighting",
     "ModelRuns",
+    "TemporalAggregation",
 ]

--- a/src/jua/market_aggregates/energy_market.py
+++ b/src/jua/market_aggregates/energy_market.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Callable
 from datetime import datetime
 
 import pandas as pd
@@ -13,6 +14,7 @@ from jua.market_aggregates.variables import (
     AggregateVariable,
     AggregateVariables,
     MWWeighting,
+    TemporalAggregation,
 )
 from jua.types import MarketZones
 from jua.weather.models import Models
@@ -90,6 +92,7 @@ class EnergyMarket:
         model_runs: list[ModelRuns],
         min_lead_time: int = 0,
         max_lead_time: int | None = None,
+        temporal_aggregation: TemporalAggregation | None = None,
     ) -> xr.Dataset:
         """Compare multiple model runs for a specific variable in this market.
 
@@ -109,17 +112,26 @@ class EnergyMarket:
             max_lead_time: Maximum forecast lead time in hours.
                 If None, returns all available lead times.
 
+            temporal_aggregation: Optional temporal resampling configuration.
+                When provided, the ``time`` dimension is resampled to the
+                specified frequency (e.g. daily) using the chosen method
+                (e.g. mean, sum). Applied client-side after fetching data.
+
         Returns:
-            xarray.Dataset containing `model_run` and `time` dimensions, with
-            `prediction_timedelta` and the queried variable as data_vars.
+            xarray.Dataset containing ``model_run`` and ``time`` dimensions, with
+            ``prediction_timedelta`` and the queried variable as data_vars.
+            When ``temporal_aggregation`` is set, the ``time`` dimension reflects
+            the resampled frequency.
 
         Raises:
             RuntimeError: If the API request fails.
 
         Examples:
-            >>> # Basic usage with integer indices
             >>> from jua import JuaClient
-            >>> from jua.market_aggregates import AggregateVariables, ModelRuns
+            >>> from jua.market_aggregates import (
+            ...     AggregateVariables, ModelRuns,
+            ...     TemporalAggregation, AggregationFrequency, AggregationMethod,
+            ... )
             >>> from jua.weather import Models
             >>> from jua.types import MarketZones
             >>>
@@ -128,40 +140,21 @@ class EnergyMarket:
             >>>     market_zone=[MarketZones.DE]
             >>> )
             >>>
-            >>> # Using integers to specify the runs
-            >>> model_runs = [
-            ...     ModelRuns(Models.EPT2, 0),  # Latest EPT2
-            ...     ModelRuns(Models.EPT1_5, [0, 1]),  # Latest 2 EPT1_5 runs
-            ... ]
+            >>> # Hourly data (default)
             >>> ds = germany.compare_runs(
             ...     agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
-            ...     model_runs=model_runs,
+            ...     model_runs=[ModelRuns(Models.EPT2, 0)],
             ...     max_lead_time=48,
             ... )
             >>>
-            >>> # Using datetime to specify the runs
-            >>> model_runs = [
-            ...     ModelRuns(
-            ...         Models.EPT2,
-            ...         [
-            ...             datetime(2025, 10, 2, 0),
-            ...             datetime(2025, 10, 1, 0),
-            ...         ]
-            ...     ),
-            ... ]
-            >>> ds = germany.compare_runs(
-            ...     agg_variable=AggregateVariables.AIR_TEMPERATURE_AT_HEIGHT_LEVEL_2M,
-            ...     model_runs=model_runs,
-            ... )
-            >>>
-            >>> # Query multiple variables for the same market
-            >>> wind_data = germany.compare_runs(
+            >>> # Daily mean aggregation
+            >>> ds_daily = germany.compare_runs(
             ...     agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
-            ...     model_runs=[ModelRuns(Models.EPT2, [0, 1])],
-            ... )
-            >>> temp_data = germany.compare_runs(
-            ...     agg_variable=AggregateVariables.AIR_TEMPERATURE_AT_HEIGHT_LEVEL_2M,
-            ...     model_runs=[ModelRuns(Models.EPT2, [0, 1])],
+            ...     model_runs=[ModelRuns(Models.EPT2, 0)],
+            ...     max_lead_time=120,
+            ...     temporal_aggregation=TemporalAggregation(
+            ...         AggregationFrequency.DAILY, AggregationMethod.MEAN,
+            ...     ),
             ... )
         """
         if isinstance(agg_variable, AggregateVariables):
@@ -179,31 +172,8 @@ class EnergyMarket:
             "max_lead_time": max_lead_time,
         }
 
-        # Group by model and collect all init_times for each model
-        all_model_runs: dict[Models, list[datetime | int]] = defaultdict(list)
-        for model_run in model_runs:
-            init_times_list = model_run.get_init_times_list()
-            all_model_runs[model_run.model].extend(init_times_list)
-
-        # For each model, resolve all init_times
-        model_to_init_times: dict[Models, list[datetime]] = {}
-        for model, init_times in all_model_runs.items():
-            model_to_init_times[model] = self._resolve_init_times_for_model(
-                model, init_times
-            )
-
-        # Map each init_time to the list of models that need it
-        # Structure: {init_time: [model1, model2, ...]}
-        init_time_to_models: dict[datetime, list[Models]] = defaultdict(list)
-        for model, resolved_times in model_to_init_times.items():
-            for init_time in resolved_times:
-                init_time_to_models[init_time].append(model)
-
-        # Query each init_time once with all models that need it
-        all_dataframes = []
-        for init_time in sorted(init_time_to_models.keys()):
-            models = init_time_to_models[init_time]
-            params = {
+        def _build_params(models: list[Models], init_time: datetime) -> dict:
+            params: dict = {
                 "models": [m.value for m in models],
                 "init_time": init_time.isoformat(),
                 "weighting": var.weighting.value,
@@ -215,52 +185,29 @@ class EnergyMarket:
                 params["min_prediction_timedelta"] = min_lead_time
             if max_lead_time is not None:
                 params["max_prediction_timedelta"] = max_lead_time
+            return params
 
-            try:
-                response = self._query_engine_api.get(
-                    "forecast/market-aggregate",
-                    params=remove_none_from_dict(params),
-                    requires_auth=True,
-                )
-
-                data = response.json()
-                df = pd.DataFrame(data)
-                if not df.empty:
-                    all_dataframes.append(df)
-
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to fetch data for models {[m.value for m in models]} at "
-                    f"init_time {init_time.isoformat()}: {e}"
-                ) from e
+        all_dataframes = self._fetch_dataframes(
+            model_runs=model_runs,
+            build_params=_build_params,
+            error_context="data",
+        )
 
         if not all_dataframes:
             ds = xr.Dataset()
             ds.assign_attrs(**attrs)
             return ds
 
-        df = pd.concat(all_dataframes, ignore_index=True)
+        ds = self._build_dataset(all_dataframes, attrs)
 
-        # create a model run column
-        df["time"] = pd.to_datetime(df["time"])
-        df["init_time"] = pd.to_datetime(df["init_time"])
-        df["model_run"] = (
-            df["model"] + " " + df["init_time"].dt.strftime("%Y-%m-%dT%H:%M")
-        )
+        # Rename the prefixed variable column to the clean variable name
+        avg_col = f"avg__{var.name}"
+        if avg_col in ds.data_vars:
+            ds = ds.rename(name_dict={avg_col: var.name})
 
-        # Extract unique model and init_time per model_run
-        model_per_run = df.groupby("model_run")["model"].first()
-        init_time_per_run = df.groupby("model_run")["init_time"].first()
-        df_for_ds = df.drop(columns=["model", "init_time"])
+        if temporal_aggregation is not None:
+            ds = _apply_temporal_aggregation(ds, temporal_aggregation)
 
-        # generate dataset
-        ds = xr.Dataset.from_dataframe(df_for_ds.set_index(["model_run", "time"]))
-        ds = ds.assign_attrs(**attrs)
-        ds.coords["model"] = ("model_run", model_per_run.values)
-        ds.coords["init_time"] = ("model_run", init_time_per_run.values)
-
-        # update variable name
-        ds = ds.rename(name_dict={f"avg__{var.name}": var.name})
         return ds
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
@@ -270,6 +217,7 @@ class EnergyMarket:
         model_runs: list[ModelRuns],
         min_lead_time: int = 0,
         max_lead_time: int | None = None,
+        temporal_aggregation: TemporalAggregation | None = None,
     ) -> xr.Dataset:
         """Compare multiple model runs with output in MW.
 
@@ -293,26 +241,47 @@ class EnergyMarket:
             max_lead_time: Maximum forecast lead time in hours. If ``None``,
                 returns all available lead times.
 
+            temporal_aggregation: Optional temporal resampling configuration.
+                When provided, the ``time`` dimension is resampled to the
+                specified frequency (e.g. daily) using the chosen method
+                (e.g. mean, sum). Applied client-side after fetching data.
+
         Returns:
             ``xarray.Dataset`` with ``model_run`` and ``time`` dimensions
             and MW data variables (e.g. ``wind_onshore_mw``).
+            When ``temporal_aggregation`` is set, the ``time`` dimension
+            reflects the resampled frequency.
 
         Raises:
             RuntimeError: If the API request fails.
 
         Examples:
             >>> from jua import JuaClient
-            >>> from jua.market_aggregates import ModelRuns
+            >>> from jua.market_aggregates import (
+            ...     ModelRuns,
+            ...     TemporalAggregation, AggregationFrequency, AggregationMethod,
+            ... )
             >>> from jua.weather import Models
             >>> from jua.types import MarketZones
             >>>
             >>> client = JuaClient()
             >>> germany = client.market_aggregates.get_market(MarketZones.DE)
             >>>
+            >>> # Hourly MW data
             >>> ds = germany.compare_runs_mw(
             ...     weighting="wind_capacity",
             ...     model_runs=[ModelRuns(Models.EPT2, [0, 1])],
             ...     max_lead_time=48,
+            ... )
+            >>>
+            >>> # Daily mean MW data
+            >>> ds_daily = germany.compare_runs_mw(
+            ...     weighting="wind_capacity",
+            ...     model_runs=[ModelRuns(Models.EPT2, [0, 1])],
+            ...     max_lead_time=120,
+            ...     temporal_aggregation=TemporalAggregation(
+            ...         AggregationFrequency.DAILY,
+            ...     ),
             ... )
         """
         attrs = {
@@ -323,25 +292,7 @@ class EnergyMarket:
             "max_lead_time": max_lead_time,
         }
 
-        all_model_runs: dict[Models, list[datetime | int]] = defaultdict(list)
-        for model_run in model_runs:
-            init_times_list = model_run.get_init_times_list()
-            all_model_runs[model_run.model].extend(init_times_list)
-
-        model_to_init_times: dict[Models, list[datetime]] = {}
-        for model, init_times in all_model_runs.items():
-            model_to_init_times[model] = self._resolve_init_times_for_model(
-                model, init_times
-            )
-
-        init_time_to_models: dict[datetime, list[Models]] = defaultdict(list)
-        for model, resolved_times in model_to_init_times.items():
-            for init_time in resolved_times:
-                init_time_to_models[init_time].append(model)
-
-        all_dataframes = []
-        for init_time in sorted(init_time_to_models.keys()):
-            models = init_time_to_models[init_time]
+        def _build_params(models: list[Models], init_time: datetime) -> dict:
             params: dict = {
                 "models": [m.value for m in models],
                 "init_time": init_time.isoformat(),
@@ -354,47 +305,23 @@ class EnergyMarket:
                 params["min_prediction_timedelta"] = min_lead_time
             if max_lead_time is not None:
                 params["max_prediction_timedelta"] = max_lead_time
+            return params
 
-            try:
-                response = self._query_engine_api.get(
-                    "forecast/market-aggregate",
-                    params=remove_none_from_dict(params),
-                    requires_auth=True,
-                )
-
-                data = response.json()
-                df = pd.DataFrame(data)
-                if not df.empty:
-                    all_dataframes.append(df)
-
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to fetch MW data for models "
-                    f"{[m.value for m in models]} at "
-                    f"init_time {init_time.isoformat()}: {e}"
-                ) from e
+        all_dataframes = self._fetch_dataframes(
+            model_runs=model_runs,
+            build_params=_build_params,
+            error_context="MW data",
+        )
 
         if not all_dataframes:
             ds = xr.Dataset()
             ds.assign_attrs(**attrs)
             return ds
 
-        df = pd.concat(all_dataframes, ignore_index=True)
+        ds = self._build_dataset(all_dataframes, attrs)
 
-        df["time"] = pd.to_datetime(df["time"])
-        df["init_time"] = pd.to_datetime(df["init_time"])
-        df["model_run"] = (
-            df["model"] + " " + df["init_time"].dt.strftime("%Y-%m-%dT%H:%M")
-        )
-
-        model_per_run = df.groupby("model_run")["model"].first()
-        init_time_per_run = df.groupby("model_run")["init_time"].first()
-        df_for_ds = df.drop(columns=["model", "init_time"])
-
-        ds = xr.Dataset.from_dataframe(df_for_ds.set_index(["model_run", "time"]))
-        ds = ds.assign_attrs(**attrs)
-        ds.coords["model"] = ("model_run", model_per_run.values)
-        ds.coords["init_time"] = ("model_run", init_time_per_run.values)
+        if temporal_aggregation is not None:
+            ds = _apply_temporal_aggregation(ds, temporal_aggregation)
 
         return ds
 
@@ -413,6 +340,99 @@ class EnergyMarket:
             A string representation with the market zones.
         """
         return f"EnergyMarket({', '.join(self.zone)})"
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_dataframes(
+        self,
+        model_runs: list[ModelRuns],
+        build_params: Callable[[list[Models], datetime], dict],
+        error_context: str,
+    ) -> list[pd.DataFrame]:
+        """Resolve model runs and fetch data from the query engine.
+
+        Args:
+            model_runs: List of ModelRuns to query.
+            build_params: Callable ``(models, init_time) -> dict`` that
+                produces the query-string parameters for a single API call.
+            error_context: Label used in error messages (e.g. "data", "MW data").
+
+        Returns:
+            List of DataFrames, one per successful API response.
+        """
+        all_model_runs: dict[Models, list[datetime | int]] = defaultdict(list)
+        for model_run in model_runs:
+            all_model_runs[model_run.model].extend(model_run.get_init_times_list())
+
+        model_to_init_times: dict[Models, list[datetime]] = {}
+        for model, init_times in all_model_runs.items():
+            model_to_init_times[model] = self._resolve_init_times_for_model(
+                model, init_times
+            )
+
+        init_time_to_models: dict[datetime, list[Models]] = defaultdict(list)
+        for model, resolved_times in model_to_init_times.items():
+            for init_time in resolved_times:
+                init_time_to_models[init_time].append(model)
+
+        all_dataframes: list[pd.DataFrame] = []
+        for init_time in sorted(init_time_to_models.keys()):
+            models = init_time_to_models[init_time]
+            params = build_params(models, init_time)
+
+            try:
+                response = self._query_engine_api.get(
+                    "forecast/market-aggregate",
+                    params=remove_none_from_dict(params),
+                    requires_auth=True,
+                )
+                data = response.json()
+                df = pd.DataFrame(data)
+                if not df.empty:
+                    all_dataframes.append(df)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to fetch {error_context} for models "
+                    f"{[m.value for m in models]} at "
+                    f"init_time {init_time.isoformat()}: {e}"
+                ) from e
+
+        return all_dataframes
+
+    @staticmethod
+    def _build_dataset(
+        dataframes: list[pd.DataFrame],
+        attrs: dict,
+    ) -> xr.Dataset:
+        """Combine fetched DataFrames into an ``xr.Dataset``.
+
+        Args:
+            dataframes: Non-empty list of DataFrames from the query engine.
+            attrs: Attributes to attach to the dataset.
+
+        Returns:
+            An ``xr.Dataset`` with ``model_run`` and ``time`` dimensions.
+        """
+        df = pd.concat(dataframes, ignore_index=True)
+
+        df["time"] = pd.to_datetime(df["time"])
+        df["init_time"] = pd.to_datetime(df["init_time"])
+        df["model_run"] = (
+            df["model"] + " " + df["init_time"].dt.strftime("%Y-%m-%dT%H:%M")
+        )
+
+        model_per_run = df.groupby("model_run")["model"].first()
+        init_time_per_run = df.groupby("model_run")["init_time"].first()
+        df_for_ds = df.drop(columns=["model", "init_time"])
+
+        ds = xr.Dataset.from_dataframe(df_for_ds.set_index(["model_run", "time"]))
+        ds = ds.assign_attrs(**attrs)
+        ds.coords["model"] = ("model_run", model_per_run.values)
+        ds.coords["init_time"] = ("model_run", init_time_per_run.values)
+
+        return ds
 
     def _resolve_init_times_for_model(
         self, model: Models, init_times: list[datetime | int]
@@ -448,7 +468,6 @@ class EnergyMarket:
             # Find the maximum index needed (highest number = furthest back)
             max_index = max(integers)
 
-            # Make a single API call to get all needed forecasts
             # Need limit = max_index + 1 because 0-indexed (index 0 requires 1 item,
             # index 2 requires 3 items, etc.)
             params = {
@@ -469,7 +488,6 @@ class EnergyMarket:
                     f"Failed to fetch available forecasts for {model.value}: {e}"
                 ) from e
 
-            # Parse the response
             forecasts_per_model = data.get("forecasts_per_model", {})
             model_key = model.value
 
@@ -485,7 +503,6 @@ class EnergyMarket:
                     f"No available forecasts found for model {model.value}"
                 )
 
-            # Check if we have enough forecasts
             if len(forecast_infos) <= max_index:
                 raise ValueError(
                     f"Requested indices up to {max_index} but only "
@@ -493,7 +510,6 @@ class EnergyMarket:
                     f"{model.value}"
                 )
 
-            # Resolve each integer index
             for index in integers:
                 if index >= len(forecast_infos):
                     raise ValueError(
@@ -501,16 +517,12 @@ class EnergyMarket:
                         f"forecast(s) available for model {model.value}"
                     )
 
-                # Index 0 means latest, 1 means 2nd latest, etc.
                 position = index
                 forecast_info = forecast_infos[position]
 
-                # Parse the init_time string to datetime
                 init_time_str = forecast_info["init_time"]
                 try:
-                    # Try parsing ISO format with timezone
                     if "T" in init_time_str:
-                        # Remove timezone info for simplicity
                         init_time_str = (
                             init_time_str.replace("Z", "").split("+")[0].split(".")[0]
                         )
@@ -524,5 +536,45 @@ class EnergyMarket:
 
                 resolved_times.add(resolved_time)
 
-        # Return sorted list in increasing (chronological) order
         return sorted(resolved_times)
+
+
+def _apply_temporal_aggregation(
+    ds: xr.Dataset,
+    aggregation: TemporalAggregation,
+) -> xr.Dataset:
+    """Resample the ``time`` dimension of a dataset.
+
+    Applies the aggregation per ``model_run`` group so that each run is
+    resampled independently.
+
+    Args:
+        ds: Dataset with a ``time`` dimension.
+        aggregation: Resampling configuration (frequency + method).
+
+    Returns:
+        A new Dataset with the ``time`` dimension resampled.
+    """
+    attrs = ds.attrs.copy()
+    coord_attrs = {name: ds.coords[name].attrs.copy() for name in ds.coords}
+
+    # prediction_timedelta is derived from init_time + time, so it cannot
+    # survive a resample in a meaningful way — drop before resampling and
+    # let users recompute if needed.
+    has_prediction_timedelta = "prediction_timedelta" in ds.data_vars
+    if has_prediction_timedelta:
+        ds = ds.drop_vars("prediction_timedelta")
+
+    resampler = ds.resample(time=aggregation.frequency.value)
+    method_fn = getattr(resampler, aggregation.method.value)
+    ds = method_fn()
+
+    attrs["temporal_aggregation_frequency"] = aggregation.frequency.value
+    attrs["temporal_aggregation_method"] = aggregation.method.value
+    ds = ds.assign_attrs(**attrs)
+
+    for name, a in coord_attrs.items():
+        if name in ds.coords:
+            ds.coords[name].attrs.update(a)
+
+    return ds

--- a/src/jua/market_aggregates/variables.py
+++ b/src/jua/market_aggregates/variables.py
@@ -15,6 +15,49 @@ class Weighting(StrEnum):
     WIND_CAPACITY = "wind_capacity"
 
 
+class AggregationFrequency(StrEnum):
+    """Frequency for temporal aggregation of market aggregate data."""
+
+    DAILY = "1D"
+    WEEKLY = "1W"
+
+
+class AggregationMethod(StrEnum):
+    """Method used to aggregate values within each time bucket."""
+
+    MEAN = "mean"
+    SUM = "sum"
+    MIN = "min"
+    MAX = "max"
+
+
+@dataclass(frozen=True)
+class TemporalAggregation:
+    """Configuration for client-side temporal resampling of market aggregate data.
+
+    Resamples the ``time`` dimension of the returned ``xr.Dataset`` into
+    fixed-frequency buckets (e.g. daily) using the specified method.
+
+    Attributes:
+        frequency: The target resampling frequency.
+        method: The reduction applied within each bucket (default: mean).
+
+    Examples:
+        >>> from jua.market_aggregates import (
+        ...     TemporalAggregation,
+        ...     AggregationFrequency,
+        ...     AggregationMethod,
+        ... )
+        >>> daily_mean = TemporalAggregation(AggregationFrequency.DAILY)
+        >>> daily_sum = TemporalAggregation(
+        ...     AggregationFrequency.DAILY, AggregationMethod.SUM,
+        ... )
+    """
+
+    frequency: AggregationFrequency
+    method: AggregationMethod = AggregationMethod.MEAN
+
+
 @dataclass(frozen=True)
 class AggregateVariable:
     """Internal representation of a variable to be used for market aggregates.

--- a/tests/functional/test_market_aggregates.py
+++ b/tests/functional/test_market_aggregates.py
@@ -9,7 +9,13 @@ from datetime import datetime
 import pytest
 
 from jua import JuaClient
-from jua.market_aggregates import AggregateVariables, ModelRuns
+from jua.market_aggregates import (
+    AggregateVariables,
+    AggregationFrequency,
+    AggregationMethod,
+    ModelRuns,
+    TemporalAggregation,
+)
 from jua.types import MarketZones
 from jua.weather import Models
 
@@ -512,3 +518,172 @@ def test_dataset_structure(client: JuaClient):
 
     except Exception as e:
         pytest.fail(f"Failed to validate dataset structure: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Temporal aggregation tests
+# ---------------------------------------------------------------------------
+
+
+def test_daily_aggregation_mean(client: JuaClient):
+    """Test that daily mean aggregation reduces the time dimension to one value per day.
+
+    Args:
+        client: JuaClient instance
+    """
+    try:
+        market = client.market_aggregates.get_market(market_zone=MarketZones.DE)
+        model_runs = [ModelRuns(Models.EPT2, 0)]
+
+        ds_hourly = market.compare_runs(
+            agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
+            model_runs=model_runs,
+            max_lead_time=72,
+        )
+
+        ds_daily = market.compare_runs(
+            agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
+            model_runs=model_runs,
+            max_lead_time=72,
+            temporal_aggregation=TemporalAggregation(AggregationFrequency.DAILY),
+        )
+
+        assert ds_daily is not None
+        assert "model_run" in ds_daily.dims
+        assert "time" in ds_daily.dims
+        assert ds_daily.sizes["time"] < ds_hourly.sizes["time"]
+        assert "temporal_aggregation_frequency" in ds_daily.attrs
+        assert ds_daily.attrs["temporal_aggregation_frequency"] == "1D"
+        assert ds_daily.attrs["temporal_aggregation_method"] == "mean"
+
+        print("✓ Daily mean aggregation works correctly")
+        print(
+            f"  Hourly time steps: {ds_hourly.sizes['time']}, "
+            f"Daily time steps: {ds_daily.sizes['time']}"
+        )
+
+    except Exception as e:
+        pytest.fail(f"Failed daily mean aggregation: {e}")
+
+
+def test_daily_aggregation_sum(client: JuaClient):
+    """Test daily sum aggregation (useful for radiation / energy variables).
+
+    Args:
+        client: JuaClient instance
+    """
+    try:
+        market = client.market_aggregates.get_market(market_zone=MarketZones.DE)
+        model_runs = [ModelRuns(Models.EPT2, 0)]
+
+        ds = market.compare_runs(
+            agg_variable=AggregateVariables.SURFACE_DOWNWELLING_SHORTWAVE_FLUX_SUM_1H,
+            model_runs=model_runs,
+            max_lead_time=72,
+            temporal_aggregation=TemporalAggregation(
+                AggregationFrequency.DAILY, AggregationMethod.SUM
+            ),
+        )
+
+        assert ds is not None
+        assert "time" in ds.dims
+        assert ds.attrs["temporal_aggregation_method"] == "sum"
+
+        print("✓ Daily sum aggregation works correctly")
+        print(f"  Daily time steps: {ds.sizes['time']}")
+
+    except Exception as e:
+        pytest.fail(f"Failed daily sum aggregation: {e}")
+
+
+def test_daily_aggregation_mw(client: JuaClient):
+    """Test daily aggregation on MW output.
+
+    Args:
+        client: JuaClient instance
+    """
+    try:
+        market = client.market_aggregates.get_market(market_zone=MarketZones.DE)
+        model_runs = [ModelRuns(Models.EPT2, 0)]
+
+        ds = market.compare_runs_mw(
+            weighting="wind_capacity",
+            model_runs=model_runs,
+            max_lead_time=72,
+            temporal_aggregation=TemporalAggregation(AggregationFrequency.DAILY),
+        )
+
+        assert ds is not None
+        assert "time" in ds.dims
+        assert ds.attrs["temporal_aggregation_frequency"] == "1D"
+        assert ds.attrs["unit"] == "MW"
+
+        print("✓ Daily MW aggregation works correctly")
+        print(f"  Daily time steps: {ds.sizes['time']}")
+
+    except Exception as e:
+        pytest.fail(f"Failed daily MW aggregation: {e}")
+
+
+def test_no_aggregation_unchanged(client: JuaClient):
+    """Test that passing no temporal_aggregation returns the same result as before.
+
+    Args:
+        client: JuaClient instance
+    """
+    try:
+        market = client.market_aggregates.get_market(market_zone=MarketZones.DE)
+        model_runs = [ModelRuns(Models.EPT2, 0)]
+
+        ds_default = market.compare_runs(
+            agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
+            model_runs=model_runs,
+            max_lead_time=48,
+        )
+
+        ds_none = market.compare_runs(
+            agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
+            model_runs=model_runs,
+            max_lead_time=48,
+            temporal_aggregation=None,
+        )
+
+        assert ds_default.sizes == ds_none.sizes
+        assert "temporal_aggregation_frequency" not in ds_default.attrs
+        assert "temporal_aggregation_frequency" not in ds_none.attrs
+
+        print("✓ No aggregation leaves dataset unchanged")
+
+    except Exception as e:
+        pytest.fail(f"Failed no-aggregation check: {e}")
+
+
+def test_aggregation_preserves_attrs(client: JuaClient):
+    """Test that temporal aggregation preserves existing dataset attributes.
+
+    Args:
+        client: JuaClient instance
+    """
+    try:
+        market = client.market_aggregates.get_market(market_zone=MarketZones.DE)
+        model_runs = [ModelRuns(Models.EPT2, 0)]
+
+        ds = market.compare_runs(
+            agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
+            model_runs=model_runs,
+            max_lead_time=72,
+            temporal_aggregation=TemporalAggregation(AggregationFrequency.DAILY),
+        )
+
+        assert "market_zone" in ds.attrs
+        assert "min_lead_time" in ds.attrs
+        assert "max_lead_time" in ds.attrs
+        assert "var_name" in ds.attrs
+        assert "temporal_aggregation_frequency" in ds.attrs
+        assert "temporal_aggregation_method" in ds.attrs
+
+        print("✓ Aggregation preserves all dataset attributes")
+        print(f"  Attributes: {list(ds.attrs.keys())}")
+
+    except Exception as e:
+        pytest.fail(f"Failed attribute preservation check: {e}")


### PR DESCRIPTION
## Summary

- Adds client-side temporal resampling (daily, weekly) to `EnergyMarket.compare_runs()` and `compare_runs_mw()` via a new optional `temporal_aggregation` parameter
- Introduces `TemporalAggregation`, `AggregationFrequency` (daily/weekly), and `AggregationMethod` (mean/sum/min/max) types in `market_aggregates.variables`
- Refactors duplicated fetch + dataset-building logic in `energy_market.py` into shared private helpers (`_fetch_dataframes`, `_build_dataset`)

### Usage

```python
from jua.market_aggregates import (
    AggregateVariables, ModelRuns,
    TemporalAggregation, AggregationFrequency, AggregationMethod,
)

ds_daily = market.compare_runs(
    agg_variable=AggregateVariables.WIND_SPEED_AT_HEIGHT_LEVEL_10M,
    model_runs=[ModelRuns(Models.EPT2, 0)],
    max_lead_time=120,
    temporal_aggregation=TemporalAggregation(
        AggregationFrequency.DAILY, AggregationMethod.MEAN,
    ),
)
```

Fully backward compatible — `temporal_aggregation` defaults to `None`.

Closes ENG-1268

## Test plan

- [x] All 132 existing unit tests pass
- [x] `pre-commit run --all-files` passes (ruff, ruff-format, isort, mypy, etc.)
- [x] Validated temporal aggregation logic with synthetic xarray datasets (mean, sum, min, max, weekly)
- [x] Verified method signatures are backward compatible (default `None`)
- [x] Run functional tests with API credentials (`just test-functional`)


Made with [Cursor](https://cursor.com)