### PR TITLE
Forecast watcher

### DIFF
--- a/examples/weather/poll_new_forecasts.py
+++ b/examples/weather/poll_new_forecasts.py
@@ -1,0 +1,45 @@
+"""
+Jua Weather SDK – Detect when new forecasts become available.
+
+Uses the built-in ForecastWatcher to poll for init_time changes.
+When a new model run appears the ``handle_new_forecast`` callback
+fires — replace its body with your own logic (fetch data, trigger a
+pipeline, send a Slack message, …).
+
+Get API credentials at https://athena.jua.ai/api-keys
+"""
+
+from jua import JuaClient
+from jua.weather import ForecastWatcher, Models
+from jua.weather._types.query_response_types import LatestForecastInfo
+
+MODELS_TO_WATCH = [Models.EPT2_HRRR]
+POLL_INTERVAL_SECONDS = 60
+MIN_PREDICTION_TIMEDELTA = 0
+
+
+def handle_new_forecast(model_name: str, info: LatestForecastInfo) -> None:
+    """Called whenever a new forecast run is detected."""
+    print(f"  >>> NEW FORECAST for {model_name}")
+    print(f"      init_time:            {info.init_time}")
+    print(f"      prediction_timedelta: {info.prediction_timedelta}h")
+    print("      (replace this with your own logic)")
+
+
+def main() -> None:
+    client = JuaClient()
+
+    watcher = ForecastWatcher(
+        client=client,
+        models=MODELS_TO_WATCH,
+        on_new_forecast=handle_new_forecast,
+        interval_seconds=POLL_INTERVAL_SECONDS,
+        min_prediction_timedelta=MIN_PREDICTION_TIMEDELTA,
+    )
+
+    print(f"Polling every {POLL_INTERVAL_SECONDS}s — press Ctrl+C to stop.\n")
+    watcher.watch()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jua/weather/__init__.py
+++ b/src/jua/weather/__init__.py
@@ -1,8 +1,17 @@
 from jua.weather._jua_dataset import JuaDataset
 from jua.weather._model import Model
+from jua.weather._watcher import ForecastWatcher
 from jua.weather._weather import Weather
 from jua.weather.models import Models
 from jua.weather.statistics import Statistics
 from jua.weather.variables import Variables
 
-__all__ = ["JuaDataset", "Model", "Models", "Statistics", "Variables", "Weather"]
+__all__ = [
+    "ForecastWatcher",
+    "JuaDataset",
+    "Model",
+    "Models",
+    "Statistics",
+    "Variables",
+    "Weather",
+]

--- a/src/jua/weather/_watcher.py
+++ b/src/jua/weather/_watcher.py
@@ -1,0 +1,180 @@
+"""Polling-based watcher for detecting new forecast availability."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from typing import Callable
+
+from pydantic import validate_call
+
+from jua.client import JuaClient
+from jua.logging import get_logger
+from jua.weather._model import Model
+from jua.weather._types.query_response_types import LatestForecastInfo
+from jua.weather.models import Models
+
+logger = get_logger(__name__)
+
+OnNewForecast = Callable[[str, LatestForecastInfo], None]
+
+
+class ForecastWatcher:
+    """Polls for new forecast availability and triggers a callback.
+
+    This is the SDK-native "smart short polling" approach: periodically
+    query ``get_latest_init_time`` for each watched model, compare
+    against the previously seen ``init_time``, and invoke the callback
+    whenever a newer run is detected.
+
+    Because weather model runs update at most a few times per day, a
+    polling interval of 60-300 seconds is typically sufficient.
+
+    Args:
+        client: An authenticated ``JuaClient``.
+        models: One or more models to watch.
+        on_new_forecast: Called with ``(model_name, LatestForecastInfo)``
+            whenever a new init_time is detected.
+        interval_seconds: Seconds between polling cycles (default 60).
+        min_prediction_timedelta: Minimum forecast horizon in hours that
+            the run must satisfy before it is considered "available"
+            (default 0).
+
+    Examples:
+        >>> from jua import JuaClient
+        >>> from jua.weather import Models, ForecastWatcher
+        >>>
+        >>> def handle(model_name, info):
+        ...     print(f"New forecast for {model_name}: {info.init_time}")
+        ...
+        >>> client = JuaClient()
+        >>> watcher = ForecastWatcher(
+        ...     client=client,
+        ...     models=[Models.EPT2_HRRR],
+        ...     on_new_forecast=handle,
+        ...     interval_seconds=120,
+        ... )
+        >>> watcher.watch()  # blocks until Ctrl-C or watcher.stop()
+    """
+
+    @validate_call(config=dict(arbitrary_types_allowed=True))
+    def __init__(
+        self,
+        client: JuaClient,
+        models: list[Models],
+        on_new_forecast: OnNewForecast,
+        interval_seconds: int = 60,
+        min_prediction_timedelta: int = 0,
+    ) -> None:
+        if not models:
+            raise ValueError("At least one model must be specified.")
+        if interval_seconds < 1:
+            raise ValueError("interval_seconds must be >= 1.")
+
+        self._client = client
+        self._models: list[Models] = models
+        self._on_new_forecast = on_new_forecast
+        self._interval_seconds = interval_seconds
+        self._min_prediction_timedelta = min_prediction_timedelta
+
+        self._sdk_models: dict[str, Model] = {}
+        for m in self._models:
+            model = self._client.weather.get_model(m)
+            self._sdk_models[model.name] = model
+
+        self._latest_init: dict[str, datetime] = {}
+        self._stop_event = threading.Event()
+
+    @property
+    def latest_init_times(self) -> dict[str, datetime]:
+        """The last-seen init_time per model name (read-only snapshot)."""
+        return dict(self._latest_init)
+
+    def check_once(self) -> list[tuple[str, LatestForecastInfo]]:
+        """Run a single polling cycle and return any new forecasts found.
+
+        Returns:
+            A list of ``(model_name, LatestForecastInfo)`` tuples for
+            every model whose ``init_time`` advanced since the last
+            check. The callback is also invoked for each.
+        """
+        new_forecasts: list[tuple[str, LatestForecastInfo]] = []
+        now = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+
+        for model_name, model in self._sdk_models.items():
+            try:
+                info = model.get_latest_init_time(
+                    min_prediction_timedelta=self._min_prediction_timedelta,
+                )
+            except Exception as e:
+                logger.warning(
+                    "[%s] %s: error fetching latest init_time: %s",
+                    now,
+                    model_name,
+                    e,
+                )
+                continue
+
+            init_time = info.init_time
+            prev = self._latest_init.get(model_name)
+
+            if prev is None:
+                self._latest_init[model_name] = init_time
+                logger.info(
+                    "[%s] %s: initial snapshot, init_time=%s",
+                    now,
+                    model_name,
+                    init_time,
+                )
+            elif init_time > prev:
+                self._latest_init[model_name] = init_time
+                logger.info(
+                    "[%s] %s: new init_time %s (was %s)",
+                    now,
+                    model_name,
+                    init_time,
+                    prev,
+                )
+                self._on_new_forecast(model_name, info)
+                new_forecasts.append((model_name, info))
+            else:
+                logger.debug(
+                    "[%s] %s: no change (latest: %s)",
+                    now,
+                    model_name,
+                    prev,
+                )
+
+        return new_forecasts
+
+    def watch(self, max_cycles: int | None = None) -> None:
+        """Block and poll until stopped or ``max_cycles`` is reached.
+
+        Args:
+            max_cycles: Stop after this many polling cycles. ``None``
+                means run indefinitely (stop via ``stop()`` or
+                ``KeyboardInterrupt``).
+        """
+        model_names = ", ".join(self._sdk_models)
+        logger.info(
+            "Watching models: %s | interval=%ds | min_prediction_timedelta=%dh",
+            model_names,
+            self._interval_seconds,
+            self._min_prediction_timedelta,
+        )
+        self._stop_event.clear()
+
+        cycle = 0
+        try:
+            while not self._stop_event.is_set():
+                if max_cycles is not None and cycle >= max_cycles:
+                    break
+                self.check_once()
+                cycle += 1
+                self._stop_event.wait(timeout=self._interval_seconds)
+        except KeyboardInterrupt:
+            logger.info("Stopped by KeyboardInterrupt.")
+
+    def stop(self) -> None:
+        """Signal the watcher to stop after the current cycle."""
+        self._stop_event.set()

--- a/tests/weather/test_watcher.py
+++ b/tests/weather/test_watcher.py
@@ -1,0 +1,239 @@
+"""Tests for ForecastWatcher polling logic."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jua.client import JuaClient
+from jua.weather import ForecastWatcher, Models
+from jua.weather._types.query_response_types import LatestForecastInfo
+
+
+@pytest.fixture
+def mock_client():
+    client = JuaClient()
+    client.settings.auth.api_key_id = "test_key_id"
+    client.settings.auth.api_key_secret = "test_key_secret"
+    return client
+
+
+def _make_info(init_time: datetime, prediction_timedelta: int = 48):
+    return LatestForecastInfo(
+        init_time=init_time,
+        prediction_timedelta=prediction_timedelta,
+    )
+
+
+class TestForecastWatcherInit:
+    def test_rejects_empty_models(self, mock_client):
+        with pytest.raises(ValueError, match="At least one model"):
+            ForecastWatcher(
+                client=mock_client,
+                models=[],
+                on_new_forecast=lambda *a: None,
+            )
+
+    def test_rejects_invalid_interval(self, mock_client):
+        with pytest.raises(ValueError, match="interval_seconds must be >= 1"):
+            ForecastWatcher(
+                client=mock_client,
+                models=[Models.EPT2],
+                on_new_forecast=lambda *a: None,
+                interval_seconds=0,
+            )
+
+
+class TestCheckOnce:
+    def test_initial_snapshot_does_not_fire_callback(self, mock_client):
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+        info = _make_info(t1)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+        )
+
+        with patch.object(
+            watcher._sdk_models["ept2"],
+            "get_latest_init_time",
+            return_value=info,
+        ):
+            result = watcher.check_once()
+
+        callback.assert_not_called()
+        assert result == []
+        assert watcher.latest_init_times["ept2"] == t1
+
+    def test_fires_callback_on_new_init_time(self, mock_client):
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+        t2 = datetime(2025, 7, 1, 6, tzinfo=timezone.utc)
+        info1 = _make_info(t1)
+        info2 = _make_info(t2)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+        )
+
+        model = watcher._sdk_models["ept2"]
+
+        with patch.object(model, "get_latest_init_time", return_value=info1):
+            watcher.check_once()
+
+        with patch.object(model, "get_latest_init_time", return_value=info2):
+            result = watcher.check_once()
+
+        callback.assert_called_once_with("ept2", info2)
+        assert len(result) == 1
+        assert result[0] == ("ept2", info2)
+        assert watcher.latest_init_times["ept2"] == t2
+
+    def test_no_callback_when_unchanged(self, mock_client):
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+        info = _make_info(t1)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+        )
+        model = watcher._sdk_models["ept2"]
+
+        with patch.object(model, "get_latest_init_time", return_value=info):
+            watcher.check_once()
+            watcher.check_once()
+
+        callback.assert_not_called()
+
+    def test_handles_api_error_gracefully(self, mock_client):
+        callback = MagicMock()
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+        )
+        model = watcher._sdk_models["ept2"]
+
+        with patch.object(
+            model,
+            "get_latest_init_time",
+            side_effect=ConnectionError("network down"),
+        ):
+            result = watcher.check_once()
+
+        callback.assert_not_called()
+        assert result == []
+
+    def test_multiple_models(self, mock_client):
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+        t2 = datetime(2025, 7, 1, 6, tzinfo=timezone.utc)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2, Models.EPT2_HRRR],
+            on_new_forecast=callback,
+        )
+
+        model_ept2 = watcher._sdk_models["ept2"]
+        model_hrrr = watcher._sdk_models["ept2_hrrr"]
+
+        with (
+            patch.object(
+                model_ept2, "get_latest_init_time", return_value=_make_info(t1)
+            ),
+            patch.object(
+                model_hrrr, "get_latest_init_time", return_value=_make_info(t1)
+            ),
+        ):
+            watcher.check_once()
+
+        # Only EPT2 advances
+        with (
+            patch.object(
+                model_ept2, "get_latest_init_time", return_value=_make_info(t2)
+            ),
+            patch.object(
+                model_hrrr, "get_latest_init_time", return_value=_make_info(t1)
+            ),
+        ):
+            result = watcher.check_once()
+
+        assert len(result) == 1
+        assert result[0][0] == "ept2"
+        callback.assert_called_once()
+
+
+class TestWatch:
+    def test_max_cycles(self, mock_client):
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+            interval_seconds=1,
+        )
+        model = watcher._sdk_models["ept2"]
+
+        with patch.object(
+            model, "get_latest_init_time", return_value=_make_info(t1)
+        ) as mock_get:
+            watcher.watch(max_cycles=3)
+            assert mock_get.call_count == 3
+
+    def test_stop_interrupts_watch(self, mock_client):
+        """stop() causes watch() to exit after the current cycle."""
+        import threading
+
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+            interval_seconds=60,
+        )
+        model = watcher._sdk_models["ept2"]
+
+        with patch.object(model, "get_latest_init_time", return_value=_make_info(t1)):
+            thread = threading.Thread(target=watcher.watch)
+            thread.start()
+            # Give it a moment to enter the loop
+            import time
+
+            time.sleep(0.2)
+            watcher.stop()
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+
+
+class TestMinPredictionTimedelta:
+    def test_passes_min_prediction_timedelta(self, mock_client):
+        callback = MagicMock()
+        t1 = datetime(2025, 7, 1, 0, tzinfo=timezone.utc)
+
+        watcher = ForecastWatcher(
+            client=mock_client,
+            models=[Models.EPT2],
+            on_new_forecast=callback,
+            min_prediction_timedelta=48,
+        )
+        model = watcher._sdk_models["ept2"]
+
+        with patch.object(
+            model, "get_latest_init_time", return_value=_make_info(t1, 72)
+        ) as mock_get:
+            watcher.check_once()
+
+        mock_get.assert_called_once_with(min_prediction_timedelta=48)


### PR DESCRIPTION
This branch adds a ForecastWatcher class — a polling-based utility that detects when new weather forecast runs become available.

What it does:
- Periodically calls get_latest_init_time for each watched model and fires a callback when a newer init_time appears
- Supports multiple models, configurable poll interval, minimum prediction timedelta filtering, and graceful error handling
- Uses threading.Event for clean start/stop semantics (watch() blocks; stop() or max_cycles exits)