### PR TITLE
fix: update MW variable name assertions to match API response

### DIFF
--- a/src/jua/market_aggregates/energy_market.py
+++ b/src/jua/market_aggregates/energy_market.py
@@ -226,8 +226,8 @@ class EnergyMarket:
 
         The response columns depend on the weighting:
 
-        - ``"wind_capacity"`` -> ``wind_onshore_mw``, ``wind_offshore_mw``
-        - ``"solar_capacity"`` -> ``solar_mw``
+        - ``"wind_capacity"`` -> ``wind_onshore``, ``wind_offshore``
+        - ``"solar_capacity"`` -> ``solar``
 
         Args:
             weighting: Capacity weighting scheme. Must be
@@ -248,7 +248,7 @@ class EnergyMarket:
 
         Returns:
             ``xarray.Dataset`` with ``model_run`` and ``time`` dimensions
-            and MW data variables (e.g. ``wind_onshore_mw``).
+            and MW data variables (e.g. ``wind_onshore``).
             When ``temporal_aggregation`` is set, the ``time`` dimension
             reflects the resampled frequency.
 

--- a/tests/functional/test_market_aggregates.py
+++ b/tests/functional/test_market_aggregates.py
@@ -375,8 +375,8 @@ def test_compare_runs_mw_wind(client: JuaClient):
         assert ds is not None, "No data returned for wind MW"
         assert "model_run" in ds.dims, "Missing model_run dimension"
         assert "time" in ds.dims, "Missing time dimension"
-        assert "wind_onshore_mw" in ds.data_vars, "Missing wind_onshore_mw variable"
-        assert "wind_offshore_mw" in ds.data_vars, "Missing wind_offshore_mw variable"
+        assert "wind_onshore" in ds.data_vars, "Missing wind_onshore variable"
+        assert "wind_offshore" in ds.data_vars, "Missing wind_offshore variable"
         assert ds.attrs.get("unit") == "MW"
         assert ds.attrs.get("weighting") == "wind_capacity"
 
@@ -406,7 +406,7 @@ def test_compare_runs_mw_solar(client: JuaClient):
         assert ds is not None, "No data returned for solar MW"
         assert "model_run" in ds.dims, "Missing model_run dimension"
         assert "time" in ds.dims, "Missing time dimension"
-        assert "solar_mw" in ds.data_vars, "Missing solar_mw variable"
+        assert "solar" in ds.data_vars, "Missing solar variable"
         assert ds.attrs.get("unit") == "MW"
         assert ds.attrs.get("weighting") == "solar_capacity"
 


### PR DESCRIPTION
## Summary
- Fix functional tests expecting `_mw` suffixed variable names (`wind_onshore_mw`, `wind_offshore_mw`, `solar_mw`) when the API returns `wind_onshore`, `wind_offshore`, and `solar`
- Update corresponding docstrings in `energy_market.py` to reflect actual variable names

## Test plan
- [ ] `test_compare_runs_mw_wind` passes with corrected assertions
- [ ] `test_compare_runs_mw_solar` passes with corrected assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)