### PR TITLE
fix: drop duplicate MultiIndex rows in point-query transform

### DIFF
--- a/src/jua/weather/_query_engine.py
+++ b/src/jua/weather/_query_engine.py
@@ -540,6 +540,8 @@ class QueryEngine:
                 ["points", "init_time", "prediction_timedelta"],
                 inplace=True,
             )
+            # Remove duplicates, if there are any (remove once duplicates are handeled)
+            df = df.loc[~df.index.duplicated()]
 
             ds = xr.Dataset.from_dataframe(df)
             # Align point_coords with the xarray dataset's points dimension order

--- a/src/jua/weather/variables.py
+++ b/src/jua/weather/variables.py
@@ -138,6 +138,12 @@ class Variables(Enum):
     WIND_DIRECTION_AT_HEIGHT_LEVEL_10M = Variable(
         "wind_direction_at_height_level_10m", "deg", "10wdir", "wind_direction_10m"
     )
+    WIND_SPEED_OF_GUST_AT_HEIGHT_LEVEL_10M_MAX = Variable(
+        "wind_speed_of_gust_at_height_level_10m_max",
+        "m/s",
+        "10fg",
+        "wind_gust_10m_max",
+    )
     WIND_SPEED_AT_HEIGHT_LEVEL_20M = Variable(
         "wind_speed_at_height_level_20m", "m/s", None, "wind_speed_20m"
     )


### PR DESCRIPTION
## Summary
- Mirror the dedup logic already used in the grid branch of `transform_dataframe`, fixing `ValueError: cannot convert a DataFrame with a non-unique MultiIndex into xarray` for point queries on models without grid access (e.g. `ECMWF_IFS_SINGLE` in `examples/weather/forecast_multiple_models.py`).
- Root cause: PR #53 only sets server-side `group_by` for models with grid access, so non-grid-access models return ungrouped rows with duplicates. Deduping client-side is symmetric with the grid branch and robust regardless of server grouping.
- Add `WIND_SPEED_OF_GUST_AT_HEIGHT_LEVEL_10M_MAX` to `Variables`.

## Test plan
- [x] `examples/weather/forecast_multiple_models.py` runs to completion
- [ ] CI example runner passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)