### PR TITLE
Add dissemination_day_offset + expected_dissemination_datetime helper

### DIFF
--- a/src/jua/weather/_types/query_response_types.py
+++ b/src/jua/weather/_types/query_response_types.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from typing import Callable
 
 from pydantic import BaseModel, Field, field_validator
@@ -169,8 +169,70 @@ class RunDefinition(BaseModel):
     )
     dissemination_time: time | None = Field(
         default=None,
-        description="The time of day at which this run is fully disseminated",
+        description=(
+            "Wall-clock *time of day* at which this run is published by "
+            "the upstream data provider. Combined with "
+            "``dissemination_day_offset`` and the init_time to get the "
+            "absolute availability datetime — use "
+            ":meth:`expected_dissemination_datetime` rather than "
+            "interpreting this field in isolation."
+        ),
     )
+    dissemination_day_offset: int | None = Field(
+        default=None,
+        description=(
+            "Days after the init date when this run is published. "
+            "``None`` means 'same day as init, with an implicit +1 day "
+            "rollover if ``dissemination_time`` is earlier than the "
+            "init's time of day' — the convention used by every "
+            "existing NWP model (e.g. ECMWF 18Z init disseminating at "
+            "03:00 rolls to the next day). An explicit integer is "
+            "absolute (no rollover): e.g. ``5`` for ECMWF SEAS5, which "
+            "publishes on day-1 + 5 = the 6th of every month."
+        ),
+    )
+
+    def expected_dissemination_datetime(
+        self, init_datetime: datetime, init_time_of_day: time
+    ) -> datetime | None:
+        """Return the wall-clock datetime when this run is expected to be
+        available, given the init datetime it was generated from.
+
+        ``None`` is returned when ``dissemination_time`` is unknown.
+
+        Args:
+            init_datetime: The initialization datetime of this run
+                (e.g. ``datetime(2026, 5, 1, 0, 0)`` for a 00Z run).
+            init_time_of_day: The init's time of day (e.g. ``time(0, 0)``
+                for a 00Z run) — used to decide whether the implicit
+                ``<1 day`` rollover should fire when
+                ``dissemination_day_offset`` is ``None``.
+
+        Example::
+
+            # ECMWF SEAS5: init on 2026-05-01 00:00 UTC, dissem_time=12:00,
+            # dissem_day_offset=5 → available 2026-05-06 12:00 UTC.
+            run.expected_dissemination_datetime(
+                datetime(2026, 5, 1, 0, 0), time(0, 0)
+            )
+            # → datetime(2026, 5, 6, 12, 0)
+        """
+        if self.dissemination_time is None:
+            return None
+        dt = init_datetime.replace(
+            hour=self.dissemination_time.hour,
+            minute=self.dissemination_time.minute,
+            second=0,
+            microsecond=0,
+        )
+        if self.dissemination_day_offset is not None:
+            dt += timedelta(days=self.dissemination_day_offset)
+        elif self.dissemination_time < init_time_of_day:
+            # Legacy implicit rollover for models that disseminate on the
+            # same calendar day at a time earlier than the init — e.g.
+            # ECMWF 18Z run disseminating at 03:00 next-day UTC.
+            dt += timedelta(days=1)
+        return dt
 
 
 class GridBounds(BaseModel):

--- a/tests/types/test_run_definition.py
+++ b/tests/types/test_run_definition.py
@@ -1,0 +1,94 @@
+"""Tests for ``RunDefinition.expected_dissemination_datetime``."""
+
+from datetime import datetime, time
+
+from jua.weather._types.query_response_types import RunDefinition
+
+
+def _make(dissemination_time=None, dissemination_day_offset=None) -> RunDefinition:
+    return RunDefinition(
+        lead_time_set=[60, 120],
+        dissemination_time=dissemination_time,
+        dissemination_day_offset=dissemination_day_offset,
+    )
+
+
+class TestExpectedDisseminationDatetime:
+    """All the resolution paths for ``expected_dissemination_datetime``."""
+
+    def test_returns_none_when_time_missing(self):
+        run = _make(dissemination_time=None)
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 11, 0, 0), time(0, 0)
+        )
+        assert result is None
+
+    def test_legacy_same_day_no_rollover(self):
+        """00Z init, 09:00 dissemination — same day."""
+        run = _make(dissemination_time=time(9, 0))
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 11, 0, 0), time(0, 0)
+        )
+        assert result == datetime(2026, 5, 11, 9, 0)
+
+    def test_legacy_implicit_rollover(self):
+        """18Z init, 03:00 dissemination — +1 day via legacy rollover."""
+        run = _make(dissemination_time=time(3, 0))
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 11, 18, 0), time(18, 0)
+        )
+        assert result == datetime(2026, 5, 12, 3, 0)
+
+    def test_legacy_same_time_no_rollover(self):
+        """Dissemination == init time-of-day should NOT roll over."""
+        run = _make(dissemination_time=time(6, 0))
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 11, 6, 0), time(6, 0)
+        )
+        assert result == datetime(2026, 5, 11, 6, 0)
+
+    def test_explicit_offset_no_implicit_rollover(self):
+        """``dissemination_day_offset=0`` is absolute — no rollover even
+        when time_of_day < init's time_of_day."""
+        run = _make(dissemination_time=time(3, 0), dissemination_day_offset=0)
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 11, 18, 0), time(18, 0)
+        )
+        assert result == datetime(2026, 5, 11, 3, 0)
+
+    def test_seas5_d_plus_5(self):
+        """SEAS5: day-1 00Z init + D+5 12:00 dissemination → day 6 12 UTC.
+
+        This is the canonical example. ECMWF's SEAS5 ``real-time``
+        forecasts are released on the 6th of each month at 12 UTC per
+        CDS docs.
+        """
+        run = _make(dissemination_time=time(12, 0), dissemination_day_offset=5)
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 1, 0, 0), time(0, 0)
+        )
+        assert result == datetime(2026, 5, 6, 12, 0)
+
+    def test_explicit_offset_one_day(self):
+        """``dissemination_day_offset=1`` with same time-of-day."""
+        run = _make(dissemination_time=time(0, 0), dissemination_day_offset=1)
+        result = run.expected_dissemination_datetime(
+            datetime(2026, 5, 11, 0, 0), time(0, 0)
+        )
+        assert result == datetime(2026, 5, 12, 0, 0)
+
+
+class TestBackwardCompat:
+    """Ensure new field defaults keep old /meta responses parseable."""
+
+    def test_construct_without_new_field(self):
+        """Old /meta responses only have ``dissemination_time``."""
+        run = RunDefinition(lead_time_set=[60], dissemination_time=time(9, 0))
+        assert run.dissemination_day_offset is None
+
+    def test_construct_with_everything_default(self):
+        """Full-default construction also works (global defaults)."""
+        run = RunDefinition()
+        assert run.lead_time_set == []
+        assert run.dissemination_time is None
+        assert run.dissemination_day_offset is None


### PR DESCRIPTION
## Summary

Companion to [juaAI/jua-core#4939](https://github.com/juaAI/jua-core/pull/4939) (cron-driven `init_schedule` + fix SEAS5 false-missing alerts).

ECMWF SEAS5 is the first model whose availability datetime can't be inferred from `init_datetime + dissemination_time` alone — its day-1 00Z init isn't released by CDS until **the 6th of the month at 12 UTC** (a 5-day offset). The server-side PR adds a `dissemination_day_offset: int | None` field on `RunDefinition`; this PR mirrors it on the SDK and adds a helper that resolves the absolute datetime.

## Changes

**`RunDefinition`**:
- **New field** `dissemination_day_offset: int | None = None`. `None` = legacy "same calendar day as init" with an implicit +1 day rollover when `dissemination_time < init_time_of_day` (the existing 18Z→03Z convention). Explicit integer = absolute day offset, no rollover.
- **New method** `expected_dissemination_datetime(init_datetime: datetime, init_time_of_day: time) -> datetime | None`. Returns the wall-clock datetime at which the run is expected to be available. Mirrors the monitor-side logic in jua-core's `service_monitoring`, so both sides agree on "is this run late?".
- **Doc-string refresh** on `dissemination_time` — points users at the helper rather than interpreting the time-of-day in isolation.

## Backward compatibility

Pydantic defaults `extra="ignore"`, so:
- Old SDK versions already silently ignore the new server-side `dissemination_day_offset` field. Rolling out jua-core first is safe.
- New SDK defaults the field to `None`, which preserves the pre-PR behaviour for every model in the catalog except SEAS5.

## Test plan

- [x] 9 new unit tests in `tests/types/test_run_definition.py`:
  - Returns `None` when `dissemination_time` is missing
  - Legacy same-day (no rollover)
  - Legacy implicit rollover (18Z → 03Z next day)
  - Legacy same-time (does NOT roll over)
  - Explicit `day_offset=0` (no implicit rollover even when time-of-day < init's time-of-day)
  - SEAS5 `D+5 12:00` → day 6 at 12 UTC
  - Explicit `day_offset=1`
  - Backward-compat construction without the new field
  - Backward-compat construction with full defaults
- [x] Full non-functional test suite: 151 passed, 0 failed
- [x] Ruff format + lint clean

## Rollout

Merge order: jua-core PR #4939 first (server adds the new field), then this PR (SDK exposes + uses it). Either order is safe thanks to pydantic's `extra="ignore"` default, but this sequence is cleanest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)