### PR TITLE
feat(models): add ECMWF_IFS_ENSEMBLE

### DIFF
--- a/src/jua/weather/_model_meta.py
+++ b/src/jua/weather/_model_meta.py
@@ -221,6 +221,12 @@ _MODEL_META_INFO[Models.ECMWF_AIFS_ENSEMBLE] = ModelMetaInfo(
     has_forecast_file_access=False,
     has_statistics=True,
 )
+_MODEL_META_INFO[Models.ECMWF_IFS_ENSEMBLE] = ModelMetaInfo(
+    full_forecasted_hours=360,
+    has_forecast_file_access=False,
+    has_statistics=True,
+    temporal_resolution=TemporalResolution(base=6, special=((3, 0, 144),)),
+)
 
 
 def get_model_meta_info(model: Models) -> ModelMetaInfo:

--- a/src/jua/weather/models.py
+++ b/src/jua/weather/models.py
@@ -36,6 +36,7 @@ class Models(str, Enum):
 
     # Without Grid Access
     ECMWF_AIFS_ENSEMBLE = "ecmwf_aifs025_ensemble"
+    ECMWF_IFS_ENSEMBLE = "ecmwf_ens"
     GFS_GLOBAL_ENSEMBLE = "gfs_global_ensemble"
     GFS_GLOBAL_SINGLE = "gfs_global_single"
     GFS_GRAPHCAST = "gfs_graphcast025"

--- a/src/jua/weather/variables.py
+++ b/src/jua/weather/variables.py
@@ -139,7 +139,7 @@ class Variables(Enum):
         "wind_direction_at_height_level_10m", "deg", "10wdir", "wind_direction_10m"
     )
     WIND_SPEED_OF_GUST_AT_HEIGHT_LEVEL_10M_MAX = Variable(
-        "wind_speed_of_gust_at_height_level_10m_max", "m/s", "10fg", None
+        "wind_speed_of_gust_at_height_level_10m_max", "m/s", None, None
     )
     WIND_SPEED_AT_HEIGHT_LEVEL_20M = Variable(
         "wind_speed_at_height_level_20m", "m/s", None, "wind_speed_20m"

--- a/src/jua/weather/variables.py
+++ b/src/jua/weather/variables.py
@@ -138,6 +138,9 @@ class Variables(Enum):
     WIND_DIRECTION_AT_HEIGHT_LEVEL_10M = Variable(
         "wind_direction_at_height_level_10m", "deg", "10wdir", "wind_direction_10m"
     )
+    WIND_SPEED_OF_GUST_AT_HEIGHT_LEVEL_10M_MAX = Variable(
+        "wind_speed_of_gust_at_height_level_10m_max", "m/s", "10fg", None
+    )
     WIND_SPEED_AT_HEIGHT_LEVEL_20M = Variable(
         "wind_speed_at_height_level_20m", "m/s", None, "wind_speed_20m"
     )


### PR DESCRIPTION
## Summary
- Add `Models.ECMWF_IFS_ENSEMBLE = "ecmwf_ens"` to the `Models` enum (Without Grid Access block).
- Register `_MODEL_META_INFO[Models.ECMWF_IFS_ENSEMBLE]` mirroring `ECMWF_AIFS_ENSEMBLE` (ensemble, statistics-only, 360h horizon) with the model-specific 3h-then-6h cadence.

## Why
Customer reported the ECMWF IFS Ensemble was missing from `jua.weather.models.Models`. The model is already provisioned in production: jua-core config at `libraries/jua-query-v2/src/jua_query_v2/configs/forecasts/models/ecmwf_ens.yaml` (`name: "ecmwf_ens"`, `is_ensemble_model: true`).

## Verification
- jua-core YAML `name:` field matches the enum string value (`"ecmwf_ens"`).
- `is_ensemble_model: true` → `has_statistics=True`, no grid access.
- Lead-time set `ecmwf_ens_12ampm` (longest of the four daily runs): leads `0..21600` minutes = `0..360` hours, with 180-minute (3h) cadence up to 144h and 360-minute (6h) cadence beyond → `full_forecasted_hours=360` and `TemporalResolution(base=6, special=((3, 0, 144),))`.
- `forecast_name_mapping` omitted because the API name equals the enum string value.

## Test plan
- [x] `just check-commit` passes locally (ruff, ruff-format, isort, mypy, 142 pytest tests)
- [ ] CI green