### PR TITLE
feat(api): add permissive HTTP retry policy for transient failures

### DIFF
--- a/src/jua/_api.py
+++ b/src/jua/_api.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import requests  # type: ignore[import-untyped]
 from requests import JSONDecodeError
 
+from jua._retry import build_session
 from jua.client import JuaClient
 from jua.errors.api_errors import (
     NotAuthenticatedError,
@@ -18,6 +19,10 @@ class API:
 
     This class handles API requests, authentication, URL construction,
     and error handling. Not intended for direct use by SDK users.
+
+    Transient failures (connection errors and retryable status codes such as
+    502/503/504) are retried automatically at the HTTP level according to the
+    retry settings on the client. See :class:`jua.settings.jua_settings.JuaSettings`.
     """
 
     def __init__(self, jua_client: JuaClient):
@@ -28,6 +33,7 @@ class API:
         """
         self._jua_client = jua_client
         self._user_agent = _get_user_agent()
+        self._session = build_session(jua_client.settings)
 
     def _get_headers(self, requires_auth: bool = True) -> dict:
         """Construct HTTP headers for API requests.
@@ -127,7 +133,7 @@ class API:
             JuaError: For other non-2xx responses.
         """
         headers = self._get_headers(requires_auth)
-        response = requests.get(self._get_url(url), headers=headers, params=params)
+        response = self._session.get(self._get_url(url), headers=headers, params=params)
         self._validate_response_status(response)
         return response
 
@@ -163,7 +169,7 @@ class API:
         if extra_headers is not None:
             headers.update(**extra_headers)
 
-        response = requests.post(
+        response = self._session.post(
             self._get_url(url),
             headers=headers,
             json=data,
@@ -193,7 +199,7 @@ class API:
             JuaError: For other non-2xx responses.
         """
         headers = self._get_headers(requires_auth)
-        response = requests.put(self._get_url(url), headers=headers, json=data)
+        response = self._session.put(self._get_url(url), headers=headers, json=data)
         self._validate_response_status(response)
         return response
 
@@ -214,7 +220,7 @@ class API:
             JuaError: For other non-2xx responses.
         """
         headers = self._get_headers(requires_auth)
-        response = requests.delete(self._get_url(url), headers=headers)
+        response = self._session.delete(self._get_url(url), headers=headers)
         self._validate_response_status(response)
         return response
 
@@ -238,7 +244,7 @@ class API:
             JuaError: For other non-2xx responses.
         """
         headers = self._get_headers(requires_auth)
-        response = requests.patch(self._get_url(url), headers=headers, json=data)
+        response = self._session.patch(self._get_url(url), headers=headers, json=data)
         self._validate_response_status(response)
         return response
 

--- a/src/jua/_retry.py
+++ b/src/jua/_retry.py
@@ -4,6 +4,12 @@ This module builds a :class:`requests.Session` with a permissive but bounded
 retry policy so that transient failures (connection errors and retryable status
 codes such as ``502``/``503``/``504``) are retried at the HTTP level, below the
 "retry the whole job" granularity.
+
+The session is safe to share across threads: ``urllib3``'s connection pool is
+thread-safe, the :class:`urllib3.util.retry.Retry` object is used as an
+immutable template (urllib3 copies it per request), and the session's own
+mutable state (headers, cookies, params) is never mutated after construction
+because callers pass headers/params per request.
 """
 
 from logging import getLogger
@@ -67,6 +73,11 @@ def build_retry(settings: JuaSettings) -> Retry:
 def build_session(settings: JuaSettings) -> requests.Session:
     """Create a :class:`requests.Session` configured with the retry policy.
 
+    The returned session is safe to share across threads (see the module
+    docstring). Its connection pool is sized via ``connection_pool_maxsize`` so
+    that concurrent fetches (e.g. from the lazy xarray backend) reuse pooled
+    connections instead of churning new ones.
+
     Args:
         settings: Client settings controlling the retry behavior.
 
@@ -76,7 +87,11 @@ def build_session(settings: JuaSettings) -> requests.Session:
     """
     session = requests.Session()
     retry = build_retry(settings)
-    adapter = HTTPAdapter(max_retries=retry)
+    adapter = HTTPAdapter(
+        max_retries=retry,
+        pool_connections=settings.connection_pool_maxsize,
+        pool_maxsize=settings.connection_pool_maxsize,
+    )
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session

--- a/src/jua/_retry.py
+++ b/src/jua/_retry.py
@@ -9,7 +9,7 @@ codes such as ``502``/``503``/``504``) are retried at the HTTP level, below the
 from logging import getLogger
 
 import requests  # type: ignore[import-untyped]
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter  # type: ignore[import-untyped]
 from urllib3.util.retry import Retry
 
 from jua.settings.jua_settings import JuaSettings

--- a/src/jua/_retry.py
+++ b/src/jua/_retry.py
@@ -1,0 +1,82 @@
+"""HTTP retry configuration for the Jua API clients.
+
+This module builds a :class:`requests.Session` with a permissive but bounded
+retry policy so that transient failures (connection errors and retryable status
+codes such as ``502``/``503``/``504``) are retried at the HTTP level, below the
+"retry the whole job" granularity.
+"""
+
+from logging import getLogger
+
+import requests  # type: ignore[import-untyped]
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from jua.settings.jua_settings import JuaSettings
+
+logger = getLogger(__name__)
+
+
+class _BoundedRetry(Retry):
+    """``urllib3`` retry policy that caps the honored ``Retry-After`` delay.
+
+    Servers (e.g. Cloudflare on a ``504``) can return a large ``Retry-After``
+    value such as 120 seconds. Honoring that verbatim on every retry would block
+    the caller for minutes, so we cap it by ``retry_backoff_max`` while still
+    respecting the server's request to back off.
+    """
+
+    def __init__(self, *args, retry_after_max: float | None = None, **kwargs):
+        self._retry_after_max = retry_after_max
+        super().__init__(*args, **kwargs)
+
+    def new(self, **kwargs):
+        # Preserve our custom attribute across the copies urllib3 makes
+        # internally (it calls ``new`` on every increment).
+        kwargs.setdefault("retry_after_max", self._retry_after_max)
+        return super().new(**kwargs)
+
+    def get_retry_after(self, response):
+        retry_after = super().get_retry_after(response)
+        if retry_after is None:
+            return None
+        if self._retry_after_max is not None:
+            return min(retry_after, self._retry_after_max)
+        return retry_after
+
+
+def build_retry(settings: JuaSettings) -> Retry:
+    """Build a :class:`urllib3.util.retry.Retry` from the client settings."""
+    return _BoundedRetry(
+        total=settings.max_retries,
+        connect=settings.max_retries,
+        read=settings.max_retries,
+        status=settings.max_retries,
+        backoff_factor=settings.retry_backoff_factor,
+        backoff_max=settings.retry_backoff_max,
+        status_forcelist=frozenset(settings.retry_status_codes),
+        # The Jua endpoints are read-only queries even when issued as POST, so it
+        # is safe to retry every HTTP method.
+        allowed_methods=None,
+        respect_retry_after_header=settings.respect_retry_after_header,
+        retry_after_max=settings.retry_backoff_max,
+        raise_on_status=False,
+    )
+
+
+def build_session(settings: JuaSettings) -> requests.Session:
+    """Create a :class:`requests.Session` configured with the retry policy.
+
+    Args:
+        settings: Client settings controlling the retry behavior.
+
+    Returns:
+        A session whose ``http://`` and ``https://`` adapters retry transient
+        failures according to ``settings``.
+    """
+    session = requests.Session()
+    retry = build_retry(settings)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session

--- a/src/jua/settings/jua_settings.py
+++ b/src/jua/settings/jua_settings.py
@@ -3,6 +3,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from jua.settings.authentication import AuthenticationSettings
 
+DEFAULT_RETRY_STATUS_CODES = [408, 425, 429, 500, 502, 503, 504]
+
 
 class JuaSettings(BaseSettings):
     """Settings for configuring the Jua SDK client.
@@ -17,6 +19,17 @@ class JuaSettings(BaseSettings):
         api_version: Version of the API to use (e.g., "v1").
         auth: Authentication configuration including API keys.
         print_progress: Whether to display progress bars during operations.
+        max_retries: Number of times a transient HTTP failure is retried at the
+            HTTP level before raising. Set to 0 to disable retries.
+        retry_backoff_factor: Base factor (in seconds) for the exponential backoff
+            applied between retries.
+        retry_backoff_max: Upper bound (in seconds) on the time waited between two
+            retries. Caps both the exponential backoff and any ``Retry-After``
+            header returned by the server.
+        retry_status_codes: HTTP status codes that should trigger an automatic
+            retry.
+        respect_retry_after_header: Whether to honor the ``Retry-After`` header
+            returned by the server (capped by ``retry_backoff_max``).
 
     Examples:
         Create with defaults:
@@ -27,6 +40,9 @@ class JuaSettings(BaseSettings):
             api_url="https://api.example.com",
             print_progress=False,
         )
+
+        Tune the HTTP retry behavior:
+        >>> settings = JuaSettings(max_retries=5, retry_backoff_factor=1.0)
 
         Load from environment variables:
         JUA_API_URL=https://api.example.com JUA_PRINT_PROGRESS=false python script.py
@@ -60,6 +76,49 @@ class JuaSettings(BaseSettings):
 
     print_progress: bool = Field(
         default=True, description="Whether to print progress information"
+    )
+
+    max_retries: int = Field(
+        default=3,
+        ge=0,
+        description=(
+            "Number of times a transient HTTP failure (connection errors and "
+            "retryable status codes such as 502/503/504) is retried at the HTTP "
+            "level before raising. Set to 0 to disable retries."
+        ),
+    )
+
+    retry_backoff_factor: float = Field(
+        default=0.5,
+        ge=0.0,
+        description=(
+            "Base factor in seconds for the exponential backoff applied between "
+            "retries. The n-th retry waits "
+            "retry_backoff_factor * (2 ** (n - 1)) seconds."
+        ),
+    )
+
+    retry_backoff_max: float = Field(
+        default=60.0,
+        ge=0.0,
+        description=(
+            "Upper bound in seconds on the time waited between two retries. Caps "
+            "both the exponential backoff and any Retry-After header returned by "
+            "the server."
+        ),
+    )
+
+    retry_status_codes: list[int] = Field(
+        default_factory=lambda: list(DEFAULT_RETRY_STATUS_CODES),
+        description="HTTP status codes that should trigger an automatic retry.",
+    )
+
+    respect_retry_after_header: bool = Field(
+        default=True,
+        description=(
+            "Whether to honor the Retry-After header returned by the server "
+            "(capped by retry_backoff_max)."
+        ),
     )
 
     model_config = SettingsConfigDict(

--- a/src/jua/settings/jua_settings.py
+++ b/src/jua/settings/jua_settings.py
@@ -30,6 +30,10 @@ class JuaSettings(BaseSettings):
             retry.
         respect_retry_after_header: Whether to honor the ``Retry-After`` header
             returned by the server (capped by ``retry_backoff_max``).
+        connection_pool_maxsize: Maximum number of HTTP connections kept in the
+            pool per host. Controls how many requests can reuse pooled
+            connections concurrently (e.g. when the lazy xarray backend fetches
+            chunks in parallel).
 
     Examples:
         Create with defaults:
@@ -118,6 +122,17 @@ class JuaSettings(BaseSettings):
         description=(
             "Whether to honor the Retry-After header returned by the server "
             "(capped by retry_backoff_max)."
+        ),
+    )
+
+    connection_pool_maxsize: int = Field(
+        default=16,
+        ge=1,
+        description=(
+            "Maximum number of HTTP connections kept in the pool per host. "
+            "Controls how many requests can reuse pooled connections "
+            "concurrently (e.g. when the lazy xarray backend fetches chunks in "
+            "parallel)."
         ),
     )
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,200 @@
+"""Tests for the HTTP-level retry policy of the Jua API clients."""
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from jua._retry import _BoundedRetry, build_retry, build_session
+from jua.settings.jua_settings import DEFAULT_RETRY_STATUS_CODES, JuaSettings
+
+
+class _FlakyHandler(BaseHTTPRequestHandler):
+    """Request handler that fails a configurable number of times before 200."""
+
+    # Class-level config set by the test harness.
+    fail_times = 0
+    fail_status = 504
+    retry_after = None
+
+    # Shared counter across requests.
+    request_count = 0
+    lock = threading.Lock()
+
+    def _handle(self):
+        with _FlakyHandler.lock:
+            _FlakyHandler.request_count += 1
+            count = _FlakyHandler.request_count
+
+        if count <= _FlakyHandler.fail_times:
+            self.send_response(_FlakyHandler.fail_status)
+            if _FlakyHandler.retry_after is not None:
+                self.send_header("Retry-After", str(_FlakyHandler.retry_after))
+            self.end_headers()
+            self.wfile.write(b"error")
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+    def do_GET(self):  # noqa: N802 (http.server API)
+        self._handle()
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        # Drain the request body so the connection can be reused.
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length:
+            self.rfile.read(length)
+        self._handle()
+
+    def log_message(self, *args, **kwargs):  # silence test server logging
+        pass
+
+
+@pytest.fixture
+def flaky_server():
+    """Start a local HTTP server and reset the flaky handler state."""
+    _FlakyHandler.fail_times = 0
+    _FlakyHandler.fail_status = 504
+    _FlakyHandler.retry_after = None
+    _FlakyHandler.request_count = 0
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FlakyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _fast_settings(**overrides) -> JuaSettings:
+    """Settings with zero backoff so retries do not sleep during tests."""
+    params = dict(
+        max_retries=3,
+        retry_backoff_factor=0.0,
+        retry_backoff_max=0.0,
+        respect_retry_after_header=False,
+    )
+    params.update(overrides)
+    return JuaSettings(**params)
+
+
+class TestBuildRetry:
+    def test_maps_settings(self):
+        settings = JuaSettings(
+            max_retries=5,
+            retry_backoff_factor=1.5,
+            retry_backoff_max=42.0,
+            retry_status_codes=[500, 503],
+            respect_retry_after_header=False,
+        )
+        retry = build_retry(settings)
+
+        assert retry.total == 5
+        assert retry.connect == 5
+        assert retry.read == 5
+        assert retry.status == 5
+        assert retry.backoff_factor == 1.5
+        assert retry.backoff_max == 42.0
+        assert set(retry.status_forcelist) == {500, 503}
+        assert retry.respect_retry_after_header is False
+        # All methods (including POST) should be retried.
+        assert retry.allowed_methods is None
+        # The error response is returned (and surfaced as a JuaError) rather than
+        # raising a urllib3 MaxRetryError.
+        assert retry.raise_on_status is False
+
+    def test_default_status_codes(self):
+        retry = build_retry(JuaSettings())
+        assert set(retry.status_forcelist) == set(DEFAULT_RETRY_STATUS_CODES)
+
+    def test_zero_retries(self):
+        retry = build_retry(JuaSettings(max_retries=0))
+        assert retry.total == 0
+
+
+class TestBoundedRetry:
+    def _response(self, retry_after):
+        class _Resp:
+            headers = {"Retry-After": str(retry_after)}
+
+            def getheader(self, name, default=None):
+                if name.lower() == "retry-after":
+                    return str(retry_after)
+                return default
+
+        return _Resp()
+
+    def test_caps_retry_after(self):
+        retry = _BoundedRetry(respect_retry_after_header=True, retry_after_max=60.0)
+        assert retry.get_retry_after(self._response(120)) == 60.0
+
+    def test_below_cap_is_unchanged(self):
+        retry = _BoundedRetry(respect_retry_after_header=True, retry_after_max=60.0)
+        assert retry.get_retry_after(self._response(10)) == 10.0
+
+    def test_cap_survives_new(self):
+        retry = _BoundedRetry(
+            respect_retry_after_header=True, retry_after_max=60.0
+        ).new()
+        assert retry.get_retry_after(self._response(120)) == 60.0
+
+
+class TestSessionRetries:
+    def test_session_mounts_adapters(self):
+        session = build_session(JuaSettings())
+        assert set(session.adapters) >= {"http://", "https://"}
+
+    def test_retries_on_504_then_succeeds(self, flaky_server):
+        _FlakyHandler.fail_times = 2
+        _FlakyHandler.fail_status = 504
+
+        session = build_session(_fast_settings(max_retries=3))
+        response = session.get(flaky_server)
+
+        assert response.status_code == 200
+        assert _FlakyHandler.request_count == 3
+
+    def test_retries_post_requests(self, flaky_server):
+        _FlakyHandler.fail_times = 1
+        _FlakyHandler.fail_status = 503
+
+        session = build_session(_fast_settings(max_retries=3))
+        response = session.post(flaky_server, json={"hello": "world"})
+
+        assert response.status_code == 200
+        assert _FlakyHandler.request_count == 2
+
+    def test_gives_up_after_max_retries(self, flaky_server):
+        _FlakyHandler.fail_times = 100  # always fail
+        _FlakyHandler.fail_status = 504
+
+        session = build_session(_fast_settings(max_retries=2))
+        response = session.get(flaky_server)
+
+        # raise_on_status is False, so the final 504 response is returned.
+        assert response.status_code == 504
+        assert _FlakyHandler.request_count == 3  # initial + 2 retries
+
+    def test_zero_retries_disables_retrying(self, flaky_server):
+        _FlakyHandler.fail_times = 100
+        _FlakyHandler.fail_status = 504
+
+        session = build_session(_fast_settings(max_retries=0))
+        response = session.get(flaky_server)
+
+        assert response.status_code == 504
+        assert _FlakyHandler.request_count == 1
+
+    def test_non_retryable_status_not_retried(self, flaky_server):
+        _FlakyHandler.fail_times = 100
+        _FlakyHandler.fail_status = 400  # not in the retry list
+
+        session = build_session(_fast_settings(max_retries=3))
+        response = session.get(flaky_server)
+
+        assert response.status_code == 400
+        assert _FlakyHandler.request_count == 1

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -148,6 +148,13 @@ class TestSessionRetries:
         session = build_session(JuaSettings())
         assert set(session.adapters) >= {"http://", "https://"}
 
+    def test_pool_size_from_settings(self):
+        session = build_session(JuaSettings(connection_pool_maxsize=32))
+        for scheme in ("http://", "https://"):
+            adapter = session.get_adapter(scheme)
+            assert adapter._pool_maxsize == 32
+            assert adapter._pool_connections == 32
+
     def test_retries_on_504_then_succeeds(self, flaky_server):
         _FlakyHandler.fail_times = 2
         _FlakyHandler.fail_status = 504
@@ -198,3 +205,26 @@ class TestSessionRetries:
 
         assert response.status_code == 400
         assert _FlakyHandler.request_count == 1
+
+    def test_concurrent_requests_share_session(self, flaky_server):
+        """A shared session handles many concurrent requests without error."""
+        _FlakyHandler.fail_times = 0  # all succeed
+
+        session = build_session(_fast_settings(connection_pool_maxsize=8))
+        results: list[int] = []
+        results_lock = threading.Lock()
+
+        def _worker():
+            resp = session.get(flaky_server)
+            with results_lock:
+                results.append(resp.status_code)
+
+        threads = [threading.Thread(target=_worker) for _ in range(24)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 24
+        assert all(code == 200 for code in results)
+        assert _FlakyHandler.request_count == 24


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

A customer using the xarray backend occasionally hits transient gateway errors when fetching data, e.g.:

```
jua.errors.jua_error.JuaError: JuaError: Unexpected status code: 504
... "error_name":"origin_gateway_timeout", "retryable":true, "retry_after":120 ...
```

These bubble all the way up through `xr.open_dataset` → `backend.open_dataset` → `query_engine.get_forecast_index` → `API.post`, forcing the caller to retry the *whole job*. They asked for a "somewhat permissive default retry policy on the inner HTTP fetches" so retries can happen at a lower level than "retry whole job".

## What this does

Adds an HTTP-level retry policy to the internal `API` / `QueryEngineAPI` clients. All requests now go through a shared `requests.Session` whose adapters are configured with a bounded `urllib3` `Retry`, so transient failures are retried automatically before an error is surfaced.

Retried conditions (defaults):
- Connection / read errors
- Retryable status codes: `408, 425, 429, 500, 502, 503, 504`
- Applies to **all** HTTP methods, including `POST` (the Jua query endpoints are read-only queries even though they use POST, so this is safe and is what's needed for the reported `forecast/index` 504).

When retries are exhausted, the final error response is returned and surfaced as the usual `JuaError` (`raise_on_status=False`), preserving existing error semantics.

## Thread-safety / concurrency

The lazy xarray backend (`ForecastCache`, guarded by an `RLock`) can issue HTTP fetches from multiple threads concurrently (e.g. under a dask threaded scheduler). The shared `Session` is safe for this:

- `urllib3`'s connection pool (`PoolManager`/`HTTPConnectionPool`) is thread-safe.
- The `Retry` object is used as an immutable template — urllib3 copies it per request via `new()`/`increment()` and never mutates the shared instance (`_BoundedRetry.new()` propagates the cap).
- The session's own mutable state (`headers`, `cookies`, `auth`, `params`) is never mutated after construction; headers/params are passed per call and auth is a per-request `X-API-Key` header (no cookies).

To avoid connection churn (and the `"Connection pool is full, discarding connection"` warning) under higher concurrency, the adapter's pool is sized via the new `connection_pool_maxsize` setting (default `16`) instead of urllib3's default of 10.

## Configuration

New `JuaSettings` fields (env-overridable via `JUA_*`):

| Setting | Default | Purpose |
| --- | --- | --- |
| `max_retries` | `3` | Retry attempts for transient failures (`0` disables) |
| `retry_backoff_factor` | `0.5` | Exponential backoff base (seconds) |
| `retry_backoff_max` | `60.0` | Cap on wait between retries |
| `retry_status_codes` | `[408,425,429,500,502,503,504]` | Status codes that trigger a retry |
| `respect_retry_after_header` | `True` | Honor server `Retry-After` |
| `connection_pool_maxsize` | `16` | Max pooled HTTP connections per host (for concurrent fetches) |

A custom `_BoundedRetry` subclass caps any server `Retry-After` value (e.g. Cloudflare's `120s`) by `retry_backoff_max`, so a single 504 won't stall a job for minutes while still respecting the server's request to back off.

```python
# Defaults are permissive; tune if needed:
client = JuaClient(settings=JuaSettings(max_retries=5, retry_backoff_factor=1.0))
```

## Changes

- `src/jua/_retry.py` (new): `build_session` / `build_retry` helpers and `_BoundedRetry`; sizes the connection pool.
- `src/jua/_api.py`: build a retrying `Session` in `API.__init__` and route all verbs through it.
- `src/jua/settings/jua_settings.py`: new retry + connection-pool settings with docs.
- `tests/test_retry.py` (new): unit tests for settings mapping, Retry-After capping and pool sizing, plus integration tests against a local flaky HTTP server (504/503 → 200, give-up behaviour, zero-retries, non-retryable status, POST retries, and a 24-thread concurrent shared-session test).

## Testing

- `uv run pytest` → 156 passed
- `just lint` (`pre-commit run --all-files`: ruff, ruff-format, isort, mypy, …) → clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22d1abad-fba1-4c24-bca4-9cd9be7495f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22d1abad-fba1-4c24-bca4-9cd9be7495f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

