### PR TITLE
feat(models): add hosted aifs_ens (additive)

### DIFF
--- a/src/jua/weather/_model_meta.py
+++ b/src/jua/weather/_model_meta.py
@@ -234,11 +234,13 @@ _MODEL_META_INFO[Models.ICON_GLOBAL] = ModelMetaInfo(
         special=((1, 0, 78),),
     ),
 )
-_MODEL_META_INFO[Models.ECMWF_AIFS_ENSEMBLE] = ModelMetaInfo(
-    forecast_name_mapping="ecmwf_aifs025_ensemble",
+_MODEL_META_INFO[Models.AIFS_ENS] = ModelMetaInfo(
+    has_grid_access=True,
     full_forecasted_hours=360,
-    has_forecast_file_access=False,
     has_statistics=True,
+    # 0.25 degree grid (1440x720 after south-pole drop) — matches the default
+    # num_lats=720 / num_lons=1440, so no override needed.
+    temporal_resolution=TemporalResolution(base=6),
 )
 _MODEL_META_INFO[Models.ECMWF_IFS_ENSEMBLE] = ModelMetaInfo(
     full_forecasted_hours=360,

--- a/src/jua/weather/_model_meta.py
+++ b/src/jua/weather/_model_meta.py
@@ -242,6 +242,12 @@ _MODEL_META_INFO[Models.AIFS_ENS] = ModelMetaInfo(
     # num_lats=720 / num_lons=1440, so no override needed.
     temporal_resolution=TemporalResolution(base=6),
 )
+_MODEL_META_INFO[Models.ECMWF_AIFS_ENSEMBLE] = ModelMetaInfo(
+    forecast_name_mapping="ecmwf_aifs025_ensemble",
+    full_forecasted_hours=360,
+    has_forecast_file_access=False,
+    has_statistics=True,
+)
 _MODEL_META_INFO[Models.ECMWF_IFS_ENSEMBLE] = ModelMetaInfo(
     full_forecasted_hours=360,
     has_forecast_file_access=False,

--- a/src/jua/weather/models.py
+++ b/src/jua/weather/models.py
@@ -38,6 +38,7 @@ class Models(str, Enum):
     NOAA_GFS_SINGLE = "noaa_gfs_single"
 
     # Without Grid Access
+    ECMWF_AIFS_ENSEMBLE = "ecmwf_aifs025_ensemble"
     ECMWF_IFS_ENSEMBLE = "ecmwf_ens"
     GFS_GLOBAL_ENSEMBLE = "gfs_global_ensemble"
     GFS_GLOBAL_SINGLE = "gfs_global_single"

--- a/src/jua/weather/models.py
+++ b/src/jua/weather/models.py
@@ -30,6 +30,7 @@ class Models(str, Enum):
     EPT2_HELIOS = "ept2_1_helios"
     EPT2_EUROPA = "ept2_1_europa"
     AIFS = "aifs"
+    AIFS_ENS = "aifs_ens"
     AURORA = "aurora"
     ECMWF_IFS_SINGLE = "ecmwf_ifs_single"
     ICON_EU = "icon_eu"
@@ -37,7 +38,6 @@ class Models(str, Enum):
     NOAA_GFS_SINGLE = "noaa_gfs_single"
 
     # Without Grid Access
-    ECMWF_AIFS_ENSEMBLE = "ecmwf_aifs025_ensemble"
     ECMWF_IFS_ENSEMBLE = "ecmwf_ens"
     GFS_GLOBAL_ENSEMBLE = "gfs_global_ensemble"
     GFS_GLOBAL_SINGLE = "gfs_global_single"

--- a/tests/functional/test_forecasts.py
+++ b/tests/functional/test_forecasts.py
@@ -36,6 +36,10 @@ DEFAULT_FORECAST_DATE = datetime(2025, 10, 20, 0, 0, 0)
 MODEL_SPECIFIC_FORECAST_DATES = {
     Models.EPT2_REASONING: datetime(2025, 11, 23, 0, 0, 0),
     Models.ICON_EU: datetime(2026, 2, 9, 0, 0, 0),
+    # AIFS ENS (ECMWF Open Data) backfill starts mid-2025 and is sparse at the
+    # edges; the default 2025-10-20 isn't present. Use a verified mid-history
+    # init time.
+    Models.AIFS_ENS: datetime(2026, 3, 3, 0, 0, 0),
 }
 
 SOLAR_ONLY_MODELS = {Models.EPT2_HELIOS}

--- a/tests/weather/test_aifs_ens_meta.py
+++ b/tests/weather/test_aifs_ens_meta.py
@@ -1,9 +1,10 @@
 """Regression tests for the hosted AIFS ENS model metadata.
 
-AIFS ENS replaced the retired open-meteo ``ecmwf_aifs025_ensemble``. Unlike the
-old point-only open-meteo model, the hosted ClickHouse model exposes full grid
-access plus ensemble statistics, so it must not regress back into the
-"point queries only" behaviour gated by ``has_grid_access``.
+The hosted ClickHouse ``aifs_ens`` model is added alongside the existing
+open-meteo ``ecmwf_aifs025_ensemble`` (additive / expand phase). Unlike the
+point-only open-meteo model, the hosted model exposes full grid access plus
+ensemble statistics, so it must not regress into the "point queries only"
+behaviour gated by ``has_grid_access``.
 """
 
 from jua.weather._model_meta import get_model_meta_info
@@ -20,8 +21,3 @@ def test_aifs_ens_is_fully_accessible() -> None:
     assert (meta.num_lats, meta.num_lons) == (720, 1440)
     # 0-360h forecast horizon.
     assert meta.full_forecasted_hours == 360
-
-
-def test_retired_open_meteo_aifs_ensemble_is_removed() -> None:
-    assert not hasattr(Models, "ECMWF_AIFS_ENSEMBLE")
-    assert "ecmwf_aifs025_ensemble" not in {m.value for m in Models}

--- a/tests/weather/test_aifs_ens_meta.py
+++ b/tests/weather/test_aifs_ens_meta.py
@@ -1,0 +1,27 @@
+"""Regression tests for the hosted AIFS ENS model metadata.
+
+AIFS ENS replaced the retired open-meteo ``ecmwf_aifs025_ensemble``. Unlike the
+old point-only open-meteo model, the hosted ClickHouse model exposes full grid
+access plus ensemble statistics, so it must not regress back into the
+"point queries only" behaviour gated by ``has_grid_access``.
+"""
+
+from jua.weather._model_meta import get_model_meta_info
+from jua.weather.models import Models
+
+
+def test_aifs_ens_is_fully_accessible() -> None:
+    meta = get_model_meta_info(Models.AIFS_ENS)
+    # Hosted ClickHouse grid model: grid/bbox slices must be allowed, not just points.
+    assert meta.has_grid_access is True
+    # 51-member ensemble: statistics available.
+    assert meta.has_statistics is True
+    # 0.25 degree global grid (1440x720 after south-pole drop).
+    assert (meta.num_lats, meta.num_lons) == (720, 1440)
+    # 0-360h forecast horizon.
+    assert meta.full_forecasted_hours == 360
+
+
+def test_retired_open_meteo_aifs_ensemble_is_removed() -> None:
+    assert not hasattr(Models, "ECMWF_AIFS_ENSEMBLE")
+    assert "ecmwf_aifs025_ensemble" not in {m.value for m in Models}


### PR DESCRIPTION
## Summary (additive / expand phase)
- Add `Models.AIFS_ENS = "aifs_ens"` in the **With Grid Access** block (next to `AIFS`), with `has_grid_access=True` + `has_statistics=True` (51-member ensemble, 0.25° 720x1440 grid, 360h, 6-hourly).
- **Keep** the existing `Models.ECMWF_AIFS_ENSEMBLE = "ecmwf_aifs025_ensemble"` untouched.
- Add a meta regression test for `aifs_ens` grid access.

This PR is **purely additive** so it passes all tests (incl. functional, once the backend is deployed) without depending on a coordinated removal.

## Why split
The hosted `aifs_ens` replaces the open-meteo `ecmwf_aifs025_ensemble`, but doing add+remove together is un-greenable across repos (SDK functional tests hit the live API; jua-core's SDK-integration test clones SDK `main`). Splitting into expand (add) then contract (remove) keeps every PR green at merge.

## Removal (separate, later)
Removing `ECMWF_AIFS_ENSEMBLE` happens in a follow-up contract-phase PR **after** the backend serving `aifs_ens` is deployed and the old open-meteo model is decommissioned in jua-core.

## Merge order
1. jua-core backend (add `aifs_ens`, additive) → deploy
2. **this SDK PR** → release
3. jua-core frontend (add to dashboards)
4. later: contract-phase removals (SDK + backend)

## Test plan
- [x] `just check-commit` (lint + 203 tests)
- [ ] Functional CI green once backend deployed