### PR TITLE
feat(models)!: remove retired ecmwf_aifs025_ensemble (contraction)

### DIFF
--- a/src/jua/weather/_model_meta.py
+++ b/src/jua/weather/_model_meta.py
@@ -242,12 +242,6 @@ _MODEL_META_INFO[Models.AIFS_ENS] = ModelMetaInfo(
     # num_lats=720 / num_lons=1440, so no override needed.
     temporal_resolution=TemporalResolution(base=6),
 )
-_MODEL_META_INFO[Models.ECMWF_AIFS_ENSEMBLE] = ModelMetaInfo(
-    forecast_name_mapping="ecmwf_aifs025_ensemble",
-    full_forecasted_hours=360,
-    has_forecast_file_access=False,
-    has_statistics=True,
-)
 _MODEL_META_INFO[Models.ECMWF_IFS_ENSEMBLE] = ModelMetaInfo(
     full_forecasted_hours=360,
     has_forecast_file_access=False,

--- a/src/jua/weather/models.py
+++ b/src/jua/weather/models.py
@@ -38,7 +38,6 @@ class Models(str, Enum):
     NOAA_GFS_SINGLE = "noaa_gfs_single"
 
     # Without Grid Access
-    ECMWF_AIFS_ENSEMBLE = "ecmwf_aifs025_ensemble"
     ECMWF_IFS_ENSEMBLE = "ecmwf_ens"
     GFS_GLOBAL_ENSEMBLE = "gfs_global_ensemble"
     GFS_GLOBAL_SINGLE = "gfs_global_single"

--- a/tests/weather/test_aifs_ens_meta.py
+++ b/tests/weather/test_aifs_ens_meta.py
@@ -20,3 +20,10 @@ def test_aifs_ens_is_fully_accessible() -> None:
     assert (meta.num_lats, meta.num_lons) == (720, 1440)
     # 0-360h forecast horizon.
     assert meta.full_forecasted_hours == 360
+
+
+def test_retired_open_meteo_aifs_ensemble_is_removed() -> None:
+    # The open-meteo ecmwf_aifs025_ensemble was retired; only the hosted
+    # aifs_ens remains. Guard against the enum member being reintroduced.
+    assert not hasattr(Models, "ECMWF_AIFS_ENSEMBLE")
+    assert "ecmwf_aifs025_ensemble" not in {m.value for m in Models}

--- a/tests/weather/test_aifs_ens_meta.py
+++ b/tests/weather/test_aifs_ens_meta.py
@@ -1,10 +1,9 @@
 """Regression tests for the hosted AIFS ENS model metadata.
 
-The hosted ClickHouse ``aifs_ens`` model is added alongside the existing
-open-meteo ``ecmwf_aifs025_ensemble`` (additive / expand phase). Unlike the
-point-only open-meteo model, the hosted model exposes full grid access plus
-ensemble statistics, so it must not regress into the "point queries only"
-behaviour gated by ``has_grid_access``.
+The hosted ClickHouse ``aifs_ens`` model replaced the retired open-meteo
+``ecmwf_aifs025_ensemble``. Unlike that point-only open-meteo model, the hosted
+model exposes full grid access plus ensemble statistics, so it must not regress
+into the "point queries only" behaviour gated by ``has_grid_access``.
 """
 
 from jua.weather._model_meta import get_model_meta_info


### PR DESCRIPTION
## Contraction — remove the retired open-meteo AIFS ensemble

Removes `Models.ECMWF_AIFS_ENSEMBLE` and its `_MODEL_META_INFO`. The open-meteo model is retired backend-side (replaced by the hosted `aifs_ens`, added in #82).

**BREAKING CHANGE**: `Models.ECMWF_AIFS_ENSEMBLE` removed → use `Models.AIFS_ENS` (hosted, grid access). `aifs_ens` does not serve 500hPa geopotential.

## ⚠️ Order — DRAFT
- **Base is `feat/models-aifs-ens` (#82)** so this shows a removal-only diff. Rebase onto `main` once #82 merges.
- Merge sequence: **#82 (add) merges & releases → jua-core frontend contraction (#5553) deploys → this SDK removal releases → jua-core backend contraction (#5554) deploys**.
- Functional CI will pass once the jua-core backend contraction is deployed (the live API stops listing the old id). Until then the old-id assertion in CI is expected to lag.

## Verified
`just check-commit` passes (lint + 203 tests). No remaining references to the old id.