### PR TITLE
feat(models): enable ensemble statistics for EPT2_HRRR and EPT2_EUROPA

### DIFF
--- a/src/jua/weather/_model_meta.py
+++ b/src/jua/weather/_model_meta.py
@@ -141,6 +141,7 @@ _MODEL_META_INFO[Models.EPT2_EARLY] = ModelMetaInfo(
 _MODEL_META_INFO[Models.EPT2_HRRR] = ModelMetaInfo(
     has_grid_access=True,
     full_forecasted_hours=48,
+    has_statistics=True,
     num_lats=3600,
     num_lons=7200,
     forecasts_per_day=24,
@@ -169,6 +170,7 @@ _MODEL_META_INFO[Models.EPT2_HELIOS] = ModelMetaInfo(
 _MODEL_META_INFO[Models.EPT2_EUROPA] = ModelMetaInfo(
     has_grid_access=True,
     full_forecasted_hours=48,
+    has_statistics=True,
     forecasts_per_day=24,
     temporal_resolution=TemporalResolution(base=1),
 )

--- a/tests/functional/test_forecasts.py
+++ b/tests/functional/test_forecasts.py
@@ -180,7 +180,7 @@ def test_latest_forecast(client: JuaClient, model: Models):
         )
 
 
-@pytest.mark.parametrize("model", [Models.EPT2_E])
+@pytest.mark.parametrize("model", [Models.EPT2_E, Models.EPT2_HRRR, Models.EPT2_EUROPA])
 def test_latest_forecast_with_stats(client: JuaClient, model: Models):
     """Test retrieving the latest forecast with statistics.
 

--- a/tests/weather/test_hrrr_europa_meta.py
+++ b/tests/weather/test_hrrr_europa_meta.py
@@ -1,0 +1,21 @@
+"""Regression tests for EPT2 HRRR / Europa ensemble metadata.
+
+Both regional models expose ensemble statistics through the forecast API, so
+``has_statistics`` must stay enabled — otherwise ``get_forecasts(..., statistics=...)``
+is rejected client-side before the request is sent.
+"""
+
+from jua.weather._model_meta import get_model_meta_info
+from jua.weather.models import Models
+
+
+def test_ept2_hrrr_has_ensemble_statistics() -> None:
+    meta = get_model_meta_info(Models.EPT2_HRRR)
+    assert meta.has_grid_access is True
+    assert meta.has_statistics is True
+
+
+def test_ept2_europa_has_ensemble_statistics() -> None:
+    meta = get_model_meta_info(Models.EPT2_EUROPA)
+    assert meta.has_grid_access is True
+    assert meta.has_statistics is True


### PR DESCRIPTION
## Summary
- Set `has_statistics=True` for `EPT2_HRRR` and `EPT2_EUROPA` so ensemble mean/quantile requests are allowed client-side
- Add meta regression tests and extend the functional stats test to cover both models

## Test plan
- [x] `pytest tests/weather/test_hrrr_europa_meta.py`
- [x] `pre-commit` / ruff on changed files
- [ ] Functional: `test_latest_forecast_with_stats` for HRRR and Europa
- [x] Live API check: stats query returns `mean`/`q25`/`q75` for both models


Made with [Cursor](https://cursor.com)