### PR TITLE
docs(power): use walk-forward debias in MW examples

### DIFF
--- a/examples/market_aggregates/market_aggregates_example.py
+++ b/examples/market_aggregates/market_aggregates_example.py
@@ -129,6 +129,7 @@ def main():
         weighting="wind_capacity",
         model_runs=[ModelRuns(Models.EPT2, [0, 1])],
         max_lead_time=48,
+        debias=True,
     )
     print(f"MW dataset:\n{mw_data}")
 
@@ -137,6 +138,7 @@ def main():
         weighting="solar_capacity",
         model_runs=[ModelRuns(Models.EPT2, 0)],
         max_lead_time=24,
+        debias=True,
     )
     print(f"Solar MW dataset:\n{solar_mw}")
 
@@ -150,6 +152,7 @@ def main():
         weighting="population",
         model_runs=[ModelRuns(Models.EPT2, 0)],
         max_lead_time=48,
+        debias=True,
     )
     print(f"Load (demand) MW dataset:\n{load_mw}")
 

--- a/examples/power_forecast/plot_day_ahead_timeseries.py
+++ b/examples/power_forecast/plot_day_ahead_timeseries.py
@@ -52,6 +52,7 @@ def plot_yearly_day_ahead(pf, zone: str) -> None:
         time_zone="UTC",
         start_date=start,
         end_date=end,
+        debias=True,
     )
     df = _to_frame(ds)
     if df is None or df.empty:
@@ -109,6 +110,7 @@ def plot_init_hour_comparison(pf, zone: str) -> None:
             time_zone="UTC",
             start_date=start,
             end_date=end,
+            debias=True,
         )
         df = _to_frame(ds)
         if df is None or df.empty:

--- a/examples/power_forecast/plot_power_forecast.py
+++ b/examples/power_forecast/plot_power_forecast.py
@@ -22,6 +22,7 @@ def main():
             "zone_keys": zones,
             "init_time": ["latest-3", "latest-4"],
             "max_prediction_timedelta": 4320,
+            "debias": True,
         },
         requires_auth=True,
     )

--- a/examples/power_forecast/power_forecast_example.py
+++ b/examples/power_forecast/power_forecast_example.py
@@ -66,6 +66,7 @@ def main():
             init_time="latest",
             max_prediction_timedelta=2880,
             version=stable.model_version,
+            debias=True,
         )
         print(ds_pinned)
         print()
@@ -77,6 +78,7 @@ def main():
         init_time="latest",
         max_prediction_timedelta=2880,
         version="latest",
+        debias=True,
     )
     print(ds_latest)
     print()
@@ -91,6 +93,7 @@ def main():
         version_pins=[
             {"zone_key": "DE", "psr_type": "Solar", "version": "latest"},
         ],
+        debias=True,
     )
     print(ds_pins)
     print()
@@ -103,6 +106,7 @@ def main():
         psr_types=["Solar"],
         init_time="latest",
         max_prediction_timedelta=2880,
+        debias=True,
     )
     print(ds)
     print()
@@ -115,6 +119,7 @@ def main():
             zone_keys=[zones[0]],
             init_time=[0, 1],
             max_prediction_timedelta=1440,
+            debias=True,
         )
         print(ds2)
         print()
@@ -127,6 +132,7 @@ def main():
         zone_keys=zones,
         start_time=now.replace(hour=0, minute=0, second=0, microsecond=0),
         end_time=now,
+        debias=True,
     )
     print(ds3)
     print()
@@ -140,6 +146,7 @@ def main():
             init_hour=9,  # e.g. D-1 09:00
             time_zone="UTC",
             max_init_times=10,  # stitch up to 10 matching days
+            debias=True,
         )
         print(ds4)
 

--- a/src/jua/market_aggregates/energy_market.py
+++ b/src/jua/market_aggregates/energy_market.py
@@ -284,6 +284,7 @@ class EnergyMarket:
             ...     weighting="wind_capacity",
             ...     model_runs=[ModelRuns(Models.EPT2, [0, 1])],
             ...     max_lead_time=48,
+            ...     debias=True,
             ... )
             >>>
             >>> # Predicted electricity demand (load_mw)
@@ -291,6 +292,7 @@ class EnergyMarket:
             ...     weighting="population",
             ...     model_runs=[ModelRuns(Models.EPT2, 0)],
             ...     max_lead_time=48,
+            ...     debias=True,
             ... )
             >>>
             >>> # Daily mean MW data
@@ -301,6 +303,7 @@ class EnergyMarket:
             ...     temporal_aggregation=TemporalAggregation(
             ...         AggregationFrequency.DAILY,
             ...     ),
+            ...     debias=True,
             ... )
         """
         attrs = {

--- a/src/jua/power_forecast/power_forecast.py
+++ b/src/jua/power_forecast/power_forecast.py
@@ -89,6 +89,7 @@ class PowerForecast:
         ...     psr_types=["Solar"],
         ...     init_time="latest",
         ...     max_prediction_timedelta=2880,
+        ...     debias=True,
         ... )
         >>>
         >>> # Same query against the packaged latest (preview) pointers
@@ -97,6 +98,7 @@ class PowerForecast:
         ...     psr_types=["Solar"],
         ...     init_time="latest",
         ...     version="latest",
+        ...     debias=True,
         ... )
         >>>
         >>> # Time range mode
@@ -104,6 +106,7 @@ class PowerForecast:
         ...     zone_keys=["DE", "FR"],
         ...     start_time=datetime(2025, 12, 1),
         ...     end_time=datetime(2025, 12, 3),
+        ...     debias=True,
         ... )
     """
 
@@ -348,6 +351,7 @@ class PowerForecast:
             ...     psr_types=["Solar"],
             ...     init_time="latest",
             ...     version=stable.model_version,
+            ...     debias=True,
             ... )
         """
         params: dict = {}
@@ -461,6 +465,7 @@ class PowerForecast:
             ...     zone_keys=["DE"],
             ...     psr_types=["Solar"],
             ...     init_time="latest",
+            ...     debias=True,
             ... )
             >>>
             >>> # Preview / latest serving pointers
@@ -469,6 +474,7 @@ class PowerForecast:
             ...     psr_types=["Solar"],
             ...     init_time="latest",
             ...     version="latest",
+            ...     debias=True,
             ... )
             >>>
             >>> # Freeze today's stable run id (promote-safe)
@@ -481,6 +487,7 @@ class PowerForecast:
             ...     psr_types=["Solar"],
             ...     init_time="latest",
             ...     version=stable.model_version,
+            ...     debias=True,
             ... )
             >>>
             >>> # Mix aliases per cell
@@ -492,6 +499,7 @@ class PowerForecast:
             ...     version_pins=[
             ...         {"zone_key": "DE", "psr_type": "Solar", "version": "latest"},
             ...     ],
+            ...     debias=True,
             ... )
             >>>
             >>> # Time range query
@@ -500,6 +508,7 @@ class PowerForecast:
             ...     zone_keys=["DE"],
             ...     start_time=datetime(2025, 12, 1),
             ...     end_time=datetime(2025, 12, 3),
+            ...     debias=True,
             ... )
         """
         has_horizon = init_time is not None or max_prediction_timedelta is not None
@@ -641,6 +650,7 @@ class PowerForecast:
             ...     start_date=datetime(2026, 7, 1),
             ...     end_date=datetime(2026, 7, 8),
             ...     time_zone="Europe/Berlin",
+            ...     debias=True,
             ... )
         """
         if not zone_keys or not isinstance(zone_keys, list):


### PR DESCRIPTION
## Summary
- Power Forecast and market-aggregate MW **examples** now pass `debias=True` (scripts + docstring copy-paste).
- The API / SDK default remains raw (`False`) if the flag is omitted.

## Why
New customers should copy examples that request the walk-forward MW series.

## Test plan
- [x] `ruff check` / `ruff format` on the touched files
- [ ] CI green


Made with [Cursor](https://cursor.com)