### PR TITLE
feat(weather): normalize forecast datetimes to milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ uv init && uv add jua
 Simply run `jua auth` to authenticate via your web browser. Make sure you are already logged in the [developer portal](https://developer.jua.ai).
 Alternatively, generate an API key from the [Jua dashboard](https://developer.jua.ai/api-keys) and save it to `~/.jua/default/api-key.json`.
 
+### Datetime resolution
+
+Forecast datetime values are normalized to millisecond resolution.
+Applications requiring another resolution must explicitly convert datetime
+values before further processing or persistence. Timestamp instants and
+timezone semantics remain unchanged.
+
 ## Examples
 
 ### Obtaining the metadata for a model

--- a/src/jua/weather/_lazy_loading/backend.py
+++ b/src/jua/weather/_lazy_loading/backend.py
@@ -135,7 +135,7 @@ class JuaQueryEngineBackend(BackendEntrypoint):
         init_times = (
             pd.to_datetime(index_result["init_time"], utc=True)
             .tz_localize(None)
-            .to_numpy()
+            .to_numpy(dtype="datetime64[ms]")
         )
         prediction_timedeltas = np.array(index_result["prediction_timedelta"])
         latitudes = np.array(index_result["latitude"], dtype="float32")

--- a/src/jua/weather/_query_engine.py
+++ b/src/jua/weather/_query_engine.py
@@ -39,6 +39,13 @@ from jua.weather.variables import Variables
 logger = getLogger(__name__)
 
 
+def _normalize_datetime_columns_to_milliseconds(df: pd.DataFrame) -> None:
+    """Normalize forecast datetime columns to the SDK's millisecond contract."""
+    for column in df.columns:
+        if pd.api.types.is_datetime64_any_dtype(df[column].dtype):
+            df[column] = df[column].dt.as_unit("ms")
+
+
 class QueryEngine:
     """Internal API client for Jua's weather services.
 
@@ -435,9 +442,9 @@ class QueryEngine:
         if df.empty:
             raise ValueError("No data available for the given parameters.")
 
-        # Parse times to correct units, enforce correct encoding
-        init_time = pd.to_datetime(df["init_time"], utc=True).dt.tz_localize(None)
-        df["init_time"] = init_time
+        # Parse times to correct units and enforce correct encoding
+        df["init_time"] = pd.to_datetime(df["init_time"], utc=True).dt.tz_localize(None)
+        _normalize_datetime_columns_to_milliseconds(df)
         df["prediction_timedelta"] = pd.to_timedelta(
             df["prediction_timedelta"], unit="m"
         )
@@ -502,7 +509,7 @@ class QueryEngine:
 
         Note:
             - All data variables are converted to float32 for memory efficiency
-            - Init time encoding is set to nanoseconds since epoch
+            - Init time encoding is set to milliseconds since epoch
         """
         # Set the correct index
         if points is not None:
@@ -574,7 +581,7 @@ class QueryEngine:
         # Set the correct init_time encoding
         ds.init_time.encoding = {
             "dtype": "int64",
-            "units": "nanoseconds since 1970-01-01T00:00:00",
+            "units": "milliseconds since 1970-01-01T00:00:00",
         }
 
         # obtain statistics from the DataVars if they were requested

--- a/tests/weather/test_lazy_loading_backend.py
+++ b/tests/weather/test_lazy_loading_backend.py
@@ -75,6 +75,9 @@ def lazy_dataset(mock_query_engine, mock_coordinates):
 class TestLazyLoadingIndexing:
     """Test various indexing operations on lazy-loaded dataset."""
 
+    def test_init_time_resolution_is_milliseconds(self, lazy_dataset):
+        assert str(lazy_dataset.init_time.dtype) == "datetime64[ms]"
+
     @pytest.mark.parametrize(
         "lat_slice,lon_slice",
         [

--- a/tests/weather/test_model.py
+++ b/tests/weather/test_model.py
@@ -1,6 +1,6 @@
 """Functional tests for Model.get_forecasts() with mocked API responses."""
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pandas as pd
@@ -94,6 +94,45 @@ def test_single_point_query(ept2_model, stream, print_progress):
     assert wind_data.shape == (1, 1, 7)
     assert 0.0 <= wind_data.min()
     assert wind_data.max() < 30.0
+
+
+@pytest.mark.parametrize("source_unit", ["ns", "us", "ms", "s"])
+def test_single_point_query_normalizes_datetime_resolution(ept2_model, source_unit):
+    init_time = datetime(2024, 1, 15, tzinfo=UTC)
+    df = create_point_dataframe(
+        num_points=1,
+        num_hours=1,
+        init_time=init_time,
+    )
+    df["time"] = [
+        init_time + timedelta(minutes=minutes) for minutes in df["prediction_timedelta"]
+    ]
+    mock_response = create_mock_arrow_response(
+        df,
+        timestamp_units={"init_time": source_unit, "time": source_unit},
+    )
+
+    with patch.object(
+        ept2_model._query_engine._api, "post", return_value=mock_response
+    ):
+        result = ept2_model.get_forecasts(
+            points=LatLon(lat=50.0, lon=8.0),
+            max_lead_time=1,
+            variables=[Variables.AIR_TEMPERATURE_AT_HEIGHT_LEVEL_2M],
+            stream=True,
+            print_progress=False,
+        )
+
+    ds = result.to_xarray()
+
+    assert ds.sizes["points"] == 1
+    assert ds.sizes["init_time"] == 1
+    assert ds.sizes["prediction_timedelta"] == 2
+    assert str(ds.init_time.dtype) == "datetime64[ms]"
+    assert ds.init_time.encoding["units"] == "milliseconds since 1970-01-01T00:00:00"
+    assert pd.Timestamp(ds.init_time.values[0]).to_pydatetime() == init_time.replace(
+        tzinfo=None
+    )
 
 
 @pytest.mark.parametrize("stream", [True, False])

--- a/tests/weather/test_stream.py
+++ b/tests/weather/test_stream.py
@@ -1,0 +1,23 @@
+from datetime import UTC, datetime
+
+import pandas as pd
+import pytest
+
+from jua.weather._stream import process_arrow_streaming_response
+from tests.weather.utils import create_mock_arrow_response
+
+
+@pytest.mark.parametrize("time_unit", ["ns", "us", "ms"])
+def test_process_arrow_response_preserves_wire_datetime_resolution(
+    time_unit: str,
+) -> None:
+    instant = datetime(2026, 8, 18, 9, 30, tzinfo=UTC)
+    response = create_mock_arrow_response(
+        pd.DataFrame({"time": [instant]}),
+        timestamp_units={"time": time_unit},
+    )
+
+    result = process_arrow_streaming_response(response, print_progress=False)
+
+    assert str(result["time"].dtype) == f"datetime64[{time_unit}, UTC]"
+    assert result["time"].tolist() == [pd.Timestamp(instant)]

--- a/tests/weather/utils.py
+++ b/tests/weather/utils.py
@@ -20,19 +20,34 @@ from jua.weather.statistics import Statistics
 from jua.weather.variables import Variables
 
 
-def create_mock_arrow_response(df: pd.DataFrame) -> requests.Response:
+def create_mock_arrow_response(
+    df: pd.DataFrame,
+    timestamp_units: dict[str, Literal["s", "ms", "us", "ns"]] | None = None,
+) -> requests.Response:
     """Create a mock requests.Response with Arrow IPC stream data.
 
     Args:
         df: DataFrame with columns: init_time, model, prediction_timedelta,
             latitude, longitude, and variable columns. For point queries, also
             include a 'point' column with integer indices.
+        timestamp_units: Optional Arrow timestamp units to apply by column.
 
     Returns:
         Mock Response object with Arrow data in response body.
     """
     # Convert DataFrame to Arrow Table
     table = pa.Table.from_pandas(df)
+    for column, unit in (timestamp_units or {}).items():
+        index = table.schema.get_field_index(column)
+        field = table.schema.field(index)
+        if not pa.types.is_timestamp(field.type):
+            raise TypeError(f"{column} is not a timestamp column")
+        timestamp_type = pa.timestamp(unit, tz=field.type.tz)
+        table = table.set_column(
+            index,
+            field.with_type(timestamp_type),
+            table.column(index).cast(timestamp_type),
+        )
 
     # Serialize to Arrow IPC stream format
     buffer = BytesIO()


### PR DESCRIPTION
## Summary

- normalize forecast datetime columns to millisecond resolution after Arrow decoding
- normalize lazy forecast `init_time` coordinates to `datetime64[ms]`
- use millisecond xarray encoding for `init_time`
- document the SDK's stable millisecond datetime contract
- preserve the generic Arrow reader's wire resolution outside the forecast boundary

The Query Engine may return forecast timestamps at `s`, `ms`, `us`, or `ns` resolution. The SDK now exposes a deterministic millisecond resolution while preserving timestamp instants and timezone semantics.

## Testing

- `just check-commit`
- all pre-commit hooks passed, including Ruff, isort, and mypy
- 227 unit tests passed; 159 functional tests were deselected by project configuration
- compatibility coverage verifies `s`, `ms`, `us`, and `ns` inputs all produce forecast `datetime64[ms]`
